### PR TITLE
Allow for string and fstring for record names

### DIFF
--- a/docs/reference/statements.rst
+++ b/docs/reference/statements.rst
@@ -286,7 +286,7 @@ record [initial | final] *value* [as *name*]
 ----------------------------------------------
 Record the value of an expression during each simulation.
 The value can be recorded at the start of the scenario (``initial``), at the end of the scenario (``final``), or at every time step during the scenario (if neither ``initial`` nor ``final`` is specified).
-The recorded values are available in the ``records`` dictionary of `SimulationResult`: its keys are the given names of the records (or synthesized names if not provided), and the corresponding values are either the value of the recorded expression or a tuple giving its value at each time step as appropriate.
+The recorded values are available in the ``records`` dictionary of `SimulationResult`: its keys are the given names, which may be a string or f-string, of the records (or synthesized names if not provided), and the corresponding values are either the value of the recorded expression or a tuple giving its value at each time step as appropriate.
 For debugging, the records can also be printed out using the :option:`--show-records` command-line option.
 
 When recording an entire time series (i.e. not using ``initial`` or ``final``), additional options are available, described below.

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -1364,7 +1364,12 @@ class ScenicToPythonTransformer(Transformer):
         if node.delay:
             elts = [self.visit(node.delay.value), ast.Constant(node.delay.unitStr)]
             kwargs["delay"] = ast.Tuple(elts, loadCtx)
-
+        if node.name:
+            if isinstance(node.name, ast.AST):
+                node.name = self.visit(node.name)
+            else:
+                node.name = ast.Constant(node.name)
+            
         return self.createRequirementLike(
             "record", node.value, node.lineno, node.name, kwargs
         )
@@ -1429,7 +1434,7 @@ class ScenicToPythonTransformer(Transformer):
                     ast.Constant(requirementId),  # requirement ID
                     newBody,  # body
                     ast.Constant(lineno),  # line number
-                    ast.Constant(name),  # requirement name
+                    name if isinstance(name, ast.AST) else ast.constant(name),  # requirement name
                 ],
                 keywords=keywords,
             )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -1364,11 +1364,6 @@ class ScenicToPythonTransformer(Transformer):
         if node.delay:
             elts = [self.visit(node.delay.value), ast.Constant(node.delay.unitStr)]
             kwargs["delay"] = ast.Tuple(elts, loadCtx)
-        if node.name:
-            if isinstance(node.name, ast.AST):
-                node.name = self.visit(node.name)
-            else:
-                node.name = ast.Constant(node.name)
 
         return self.createRequirementLike(
             "record", node.value, node.lineno, node.name, kwargs
@@ -1403,7 +1398,7 @@ class ScenicToPythonTransformer(Transformer):
         functionName: str,
         body: ast.AST,
         lineno: int,
-        name: Optional[str] = None,
+        name: Optional[ast.AST | str] = None,
         kwargs: Dict[str, Union[Tuple[ast.AST, ...], ast.AST]] = {},
     ):
         """Create a call to a function that implements requirement-like features, such as `record` and `terminate when`.
@@ -1427,6 +1422,11 @@ class ScenicToPythonTransformer(Transformer):
                 node = ast.Tuple(*node)
             keywords.append(ast.keyword(arg=datum, value=node))
 
+        if isinstance(name, ast.AST):
+            name = self.visit(name)
+        else:
+            name = ast.Constant(name)
+
         return ast.Expr(
             value=ast.Call(
                 func=ast.Name(functionName, loadCtx),
@@ -1434,9 +1434,7 @@ class ScenicToPythonTransformer(Transformer):
                     ast.Constant(requirementId),  # requirement ID
                     newBody,  # body
                     ast.Constant(lineno),  # line number
-                    (
-                        name if isinstance(name, ast.AST) else ast.Constant(name)
-                    ),  # requirement name
+                    (name),  # requirement name
                 ],
                 keywords=keywords,
             )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -1369,7 +1369,7 @@ class ScenicToPythonTransformer(Transformer):
                 node.name = self.visit(node.name)
             else:
                 node.name = ast.Constant(node.name)
-            
+
         return self.createRequirementLike(
             "record", node.value, node.lineno, node.name, kwargs
         )
@@ -1434,7 +1434,9 @@ class ScenicToPythonTransformer(Transformer):
                     ast.Constant(requirementId),  # requirement ID
                     newBody,  # body
                     ast.Constant(lineno),  # line number
-                    name if isinstance(name, ast.AST) else ast.constant(name),  # requirement name
+                    (
+                        name if isinstance(name, ast.AST) else ast.Constant(name)
+                    ),  # requirement name
                 ],
                 keywords=keywords,
             )

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -2121,8 +2121,8 @@ scenic_require_stmt:
         s.Require(cond=e, prob=p, name=n, LOCATIONS)
      }
 scenic_require_stmt_name:
+    | a=strings {a}
     | a=(NAME | NUMBER) { a.string }
-    | a=STRING { a.string[1:-1] }
 
 scenic_record_stmt:
     | "record" e=expression \

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -2249,6 +2249,23 @@ def test_record():
         (3, (6, 0, 0)),
     )
 
+def test_record_keys():
+    scenario = compileScenic(
+        """
+        behavior Foo():
+            for i in range(3):
+                self.position = self.position + 2@0
+                wait
+        ego = new Object with behavior Foo
+        for i in range(2):
+            obj = new Object with behvior Foo
+            record obj.position as f"position_{i}"
+        terminate when ego.position.x >= 6
+        """
+    )
+    result = sampleResult(scenario, maxSteps=4)
+    assert "position_0" in result.records 
+    assert "position_1" in result.records
 
 ## lastActions Property
 def test_lastActions():

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -2267,6 +2267,29 @@ def test_record_keys():
     assert "ego_position_0" in result.records
 
 
+def test_record_keys_multiple():
+    scenario = compileScenic(
+        """
+        behavior Foo():
+            for i in range(3):
+                self.position = self.position + 2@0
+                wait
+        ego = new Object with behavior Foo
+        for i in range(2):
+            record ego.position as f"ego_position_{i}"
+        terminate when ego.position.x >= 6
+        """
+    )
+    result = sampleResult(scenario, maxSteps=4)
+    assert "ego_position_0" in result.records
+    assert "ego_position_1" in result.records
+    assert len(result.records["ego_position_0"]) == len(result.records["ego_position_1"])
+    for record1, record2 in zip(
+        result.records["ego_position_0"], result.records["ego_position_0"]
+    ):
+        assert record1 == record2
+
+
 ## lastActions Property
 def test_lastActions():
     scenario = compileScenic(

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -2249,6 +2249,7 @@ def test_record():
         (3, (6, 0, 0)),
     )
 
+
 def test_record_keys():
     scenario = compileScenic(
         """
@@ -2257,15 +2258,14 @@ def test_record_keys():
                 self.position = self.position + 2@0
                 wait
         ego = new Object with behavior Foo
-        for i in range(2):
-            obj = new Object with behvior Foo
-            record obj.position as f"position_{i}"
+        i=0
+        record ego.position as f"ego_position_{i}"
         terminate when ego.position.x >= 6
         """
     )
     result = sampleResult(scenario, maxSteps=4)
-    assert "position_0" in result.records 
-    assert "position_1" in result.records
+    assert "ego_position_0" in result.records
+
 
 ## lastActions Property
 def test_lastActions():

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1138,7 +1138,7 @@ class TestRequire:
         mod = parse_string_helper("require X as 'requirement name'")
         stmt = mod.body[0]
         match stmt:
-            case Require(Name("X"), None, "requirement name"):
+            case Require(Name("X"), None, ast.Constant("requirement name")):
                 assert True
             case _:
                 assert False
@@ -1170,6 +1170,17 @@ class TestRequire:
             case _:
                 assert False
 
+    def test_require_always_with_name_fstr(self):
+        mod = parse_string_helper("require always X as f'safety'")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(
+                Always(Name("X")), None, ast.JoinedStr(values=[ast.Constant("safety")])
+            ):
+                assert True
+            case _:
+                assert False
+
     def test_require_eventually(self):
         mod = parse_string_helper("require eventually X")
         stmt = mod.body[0]
@@ -1184,6 +1195,19 @@ class TestRequire:
         stmt = mod.body[0]
         match stmt:
             case Require(Eventually(Name("X")), None, "liveness"):
+                assert True
+            case _:
+                assert False
+
+    def test_require_eventually_with_name_fstr(self):
+        mod = parse_string_helper("require eventually X as f'liveness'")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(
+                Eventually(Name("X")),
+                None,
+                ast.JoinedStr(values=[ast.Constant("liveness")]),
+            ):
                 assert True
             case _:
                 assert False
@@ -1204,6 +1228,24 @@ class TestRecord:
         stmt = mod.body[0]
         match stmt:
             case Record(Name("x"), "name"):
+                assert True
+            case _:
+                assert False
+
+    def test_record_named_fstr(self):
+        mod = parse_string_helper("record x as f'name'")
+        stmt = mod.body[0]
+        match stmt:
+            case Record(Name("x"), ast.JoinedStr(values=[ast.Constant(value="name")])):
+                assert True
+            case _:
+                assert False
+
+    def test_record_named_str(self):
+        mod = parse_string_helper("record x as 'name'")
+        stmt = mod.body[0]
+        match stmt:
+            case Record(Name("x"), ast.Constant("name")):
                 assert True
             case _:
                 assert False
@@ -1283,6 +1325,26 @@ class TestRecord:
             case _:
                 assert False
 
+    def test_record_initial_named_str(self):
+        mod = parse_string_helper("record initial x as 'name'")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordInitial(Name("x"), ast.Constant("name")):
+                assert True
+            case _:
+                assert False
+
+    def test_record_intial_named_fstr(self):
+        mod = parse_string_helper("record initial x as f'name'")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordInitial(
+                Name("x"), ast.JoinedStr(values=[ast.Constant(value="name")])
+            ):
+                assert True
+            case _:
+                assert False
+
     def test_record_final(self):
         mod = parse_string_helper("record final x")
         stmt = mod.body[0]
@@ -1297,6 +1359,24 @@ class TestRecord:
         stmt = mod.body[0]
         match stmt:
             case RecordFinal(Name("x"), "name"):
+                assert True
+            case _:
+                assert False
+
+    def test_record_final_named_str(self):
+        mod = parse_string_helper("record final x as 'name'")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordFinal(Name("x"), ast.Constant("name")):
+                assert True
+            case _:
+                assert False
+
+    def test_record_final_named_fstr(self):
+        mod = parse_string_helper("record final x as f'name'")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordFinal(Name("x"), ast.JoinedStr(values=[ast.Constant("name")])):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1233,10 +1233,51 @@ class TestRecord:
                 assert False
 
     def test_record_named_fstr(self):
-        mod = parse_string_helper("record x as f'name'")
+        mod = parse_string_helper("record x as f'name_{3*2}'")
         stmt = mod.body[0]
         match stmt:
-            case Record(Name("x"), ast.JoinedStr(values=[ast.Constant(value="name")])):
+            case Record(
+                Name("x"),
+                ast.JoinedStr(
+                    values=[
+                        ast.Constant(value="name_"),
+                        ast.FormattedValue(
+                            value=ast.BinOp(
+                                left=ast.Constant(value=3),
+                                op=ast.Mult(),
+                                right=ast.Constant(value=2),
+                            )
+                        ),
+                    ]
+                ),
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_record_named_fstr_lambda(self):
+        mod = parse_string_helper("record x as f'name_{(lambda x: 3)(4)}'")
+        stmt = mod.body[0]
+        match stmt:
+            case Record(
+                Name("x"),
+                ast.JoinedStr(
+                    values=[
+                        ast.Constant(value="name_"),
+                        ast.FormattedValue(
+                            value=ast.Call(
+                                func=ast.Lambda(
+                                    args=ast.arguments(
+                                        args=[ast.arg(arg="x")],
+                                    ),
+                                    body=ast.Constant(value=3),
+                                ),
+                                args=[ast.Constant(value=4)],
+                            )
+                        ),
+                    ]
+                ),
+            ):
                 assert True
             case _:
                 assert False


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
Modified grammar and compiler to allow for using fstring and strings as names in record statements.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->