### PR TITLE
Revert Black to Python 3.8 Compatible Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ test-full = [  # like 'test' but adds dependencies for optional features
 ]
 dev = [
 	"scenic[test-full]",
-	"black ~= 25.1.0",
+	"black ~= 23.12.1",
 	"isort ~= 5.12.0",
 	"pre-commit ~= 3.0",
 	"pytest-cov >= 3.0.0",


### PR DESCRIPTION
### Description
Revert Black to Python 3.8 Compatible Version

### Issue Link
N/A

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A