### PR TITLE
Fix ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-26.04
   tools:
-    python: "3.10"
+    python: "3.14"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->

ReadTheDocs no longer provides Ubuntu 20.04: update to the latest currently-supported version.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->