### PR TITLE
Drop PDF and ePub docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,9 +15,6 @@ build:
 sphinx:
   configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: all
-
 # Optionally declare the Python requirements required to build your docs
 python:
   install:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->

We're now getting Unicode errors from LaTeX during the PDF build of the docs; rather than fix it we are just going to drop the PDF and ePub builds, since probably nobody is using them.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [ ] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->