### PR TITLE
Derive lane-specific halt points from OpenDRIVE signals

### DIFF
--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -24,6 +24,7 @@ import pickle
 import struct
 import time
 from typing import Dict, FrozenSet, List, Optional, Sequence, Tuple, Union
+import warnings
 import weakref
 
 import attr
@@ -397,10 +398,10 @@ class LinearElement(NetworkElement):
     # the start of this element's centerline to its end. For backward lanes this
     # is travel order, the reverse of OpenDRIVE road-s order.
     SignalEntry = Tuple[
-         float,   # element-local s, used for ordering and bisect
-         "Signal",  # controlling signal
-         float,   # OpenDRIVE road s of the effective stopping position
-         float,   # OpenDRIVE road t at this element's centerline
+        float,  # element-local s, used for ordering and bisect
+        "Signal",  # controlling signal
+        float,  # OpenDRIVE road s of the effective stopping position
+        float,  # OpenDRIVE road t at this element's centerline
     ]
 
     #: OpenDRIVE road-s interval covered by this element, if known.
@@ -1010,15 +1011,17 @@ class Signal:
     uid: str = None
     #: ID number as in OpenDRIVE (unique ID of the signal within the database)
     openDriveID: int
-    #: Country code of the signal
-    country: str
+    #: Deprecated country code of the signal; use `tags` instead.
+    _country: str
     #: Type identifier according to country code.
     type: str
-    #: Subtype identifier according to country code (``None`` if absent).
-    subtype: Optional[str] = None
+    #: Deprecated subtype identifier; use `tags` instead.
+    _subtype: Optional[str] = None
     #: Broad category or original OpenDRIVE string for each ``<priority>`` entry.
     #: Empty for signals without 1.8+ priority semantics.
     priorities: Tuple[Union[SignalPriorityType, str], ...] = ()
+    #: Exact OpenDRIVE 1.8+ semantic tag strings.
+    tags: FrozenSet[str] = frozenset()
     #: Longitudinal s-coordinate along the road reference line (OpenDRIVE ``s``).
     #: Physical pole location in 1.8+; logical effect station if `sIsLogical`.
     s: Optional[float] = None
@@ -1040,6 +1043,28 @@ class Signal:
     position: Optional[Vector] = None
     #: Maneuvers that require this signal to be green (empty if unknown).
     controlledManeuvers: Tuple[Maneuver, ...] = ()
+
+    @property
+    def country(self) -> str:
+        """Deprecated country code; use `tags` instead."""
+        warnings.warn(
+            "Signal.country is deprecated; use Signal.tags and OpenDRIVE 1.8 "
+            "semantic metadata instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._country
+
+    @property
+    def subtype(self) -> Optional[str]:
+        """Deprecated country-specific subtype; use `tags` instead."""
+        warnings.warn(
+            "Signal.subtype is deprecated; use Signal.tags and OpenDRIVE 1.8 "
+            "semantic metadata instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._subtype
 
     def hasPriority(self, priority: SignalPriorityType) -> bool:
         """Whether this signal lists the given OpenDRIVE priority semantic."""
@@ -1348,7 +1373,7 @@ class Network:
 
         :meta private:
         """
-        return 36
+        return 37
 
     class DigestMismatchError(Exception):
         """Exception raised when loading a cached map not matching the original file."""

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -27,7 +27,7 @@ import weakref
 
 import attr
 import shapely
-from shapely.geometry import MultiPolygon, Polygon
+from shapely.geometry import MultiPolygon, Point as ShapelyPoint, Polygon
 
 from scenic.core.distributions import (
     RejectionException,
@@ -145,6 +145,34 @@ class ManeuverType(enum.Enum):
             return ManeuverType.RIGHT_TURN
         else:
             return ManeuverType.STRAIGHT
+
+
+@enum.unique
+class SignalPriorityType(enum.Enum):
+    """OpenDRIVE ``e_signals_semantics_priority`` literals."""
+
+    FOUR_WAY = "4way"
+    KEEP_CLEAR_LINE = "keepClearLine"
+    NO_PARKING_LINE = "noParkingLine"
+    NO_TURN_ON_RED = "noTurnOnRed"
+    PRIORITY_ROAD_END = "priorityRoadEnd"
+    PRIORITY_ROAD = "priorityRoad"
+    PRIORITY_TO_THE_RIGHT_RULE = "priorityToTheRightRule"
+    STOP_LINE = "stopLine"
+    STOP = "stop"
+    TRAFFIC_LIGHT = "trafficLight"
+    TURN_ON_RED_ALLOWED = "turnOnRedAllowed"
+    WAITING_LINE = "waitingLine"
+    YIELD = "yield"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def fromOpenDrive(cls, type_str: str) -> SignalPriorityType:
+        """Map an OpenDRIVE priority string to an enum member."""
+        for member in cls:
+            if member is not cls.UNKNOWN and member.value == type_str:
+                return member
+        return cls.UNKNOWN
 
 
 @attr.s(auto_attribs=True, kw_only=True, eq=False)
@@ -571,6 +599,22 @@ class Lane(_ContainsCenterline, LinearElement):
         """Get the LaneSection passing through a given point."""
         return self.network.findPointIn(point, self.sections, reject)
 
+    def haltPointAhead(self, position, lookahead: float = 80.0) -> Optional[Vector]:
+        """Nearest `Signal.stoppingPointOn` this lane still ahead of ``position``."""
+        if self.road is None:
+            return None
+        here = self.centerline.lineString.project(ShapelyPoint(position.x, position.y))
+        best = None
+        best_ahead = None
+        for sig in self.road.signals:
+            pt = sig.stoppingPointOn(self)
+            if pt is None:
+                continue
+            ahead = self.centerline.lineString.project(ShapelyPoint(pt.x, pt.y)) - here
+            if 0 <= ahead <= lookahead and (best_ahead is None or ahead < best_ahead):
+                best, best_ahead = pt, ahead
+        return best
+
 
 @attr.s(auto_attribs=True, kw_only=True, repr=False, eq=False)
 class RoadSection(LinearElement):
@@ -809,6 +853,20 @@ class Intersection(NetworkElement):
         return tuple(m.connectingLane.orientation[point] for m in maneuvers)
 
 
+@attr.s(auto_attribs=True, frozen=True, kw_only=True)
+class SignalLink:
+    """OpenDRIVE ``<reference>`` from this signal to another signal or object.
+
+    Distinct from ``<signalReference>``, which re-applies the same signal on
+    another road. A typical 1.8+ use is a traffic light linking to a stop line
+    (``elementType="signal"``, ``type="stopline"``).
+    """
+
+    elementId: str
+    elementType: str
+    type: Optional[str] = None
+
+
 @attr.s(auto_attribs=True, kw_only=True, repr=False, eq=False)
 class Signal:
     """Traffic lights, stop signs, etc.
@@ -825,11 +883,202 @@ class Signal:
     country: str
     #: Type identifier according to country code.
     type: str
+    #: Subtype identifier according to country code (``None`` if absent).
+    subtype: Optional[str] = None
+    #: OpenDRIVE ``e_signals_semantics_priority`` entries (empty if unknown / pre-1.8).
+    #: All ``<priority>`` children are kept; they are not collapsed to a single type.
+    priorities: Tuple[SignalPriorityType, ...] = ()
+    #: Longitudinal s-coordinate along the road reference line (OpenDRIVE ``s``).
+    #: Physical pole location in 1.8+; logical effect station if `sIsLogical`.
+    s: Optional[float] = None
+    #: Lateral t-coordinate from the reference line (OpenDRIVE ``t``; +t = left).
+    t: Optional[float] = None
+    #: OpenDRIVE signal orientation: ``"+"``, ``"-"``, or ``"none"``.
+    orientation: Optional[str] = None
+    #: OpenDRIVE ``<validity>`` lane range ``(fromLane, toLane)``, if any.
+    validity: Optional[Tuple[int, int]] = None
+    #: OpenDRIVE ``<reference>`` links (e.g. light → stop line).
+    references: Tuple[SignalLink, ...] = ()
+    #: True when deprecated ``<positionRoad>`` / ``<positionInertial>`` is present,
+    #: so `s` is the logical effect station rather than the pole.
+    sIsLogical: bool = False
+    #: Station along the parent road where an ego should halt for this signal.
+    #: May differ from `s` (e.g. a traffic light's pole vs its stop line).
+    #: ``None`` if we cannot derive one (typical for a connector-only light).
+    stoppingS: Optional[float] = None
+    #: World-space device/pole position from OpenDRIVE ``(s, t)``.
+    position: Optional[Vector] = None
+    #: Maneuvers that require this signal to be green (empty if unknown).
+    controlledManeuvers: Tuple[Maneuver, ...] = ()
+
+    def hasPriority(self, priority: SignalPriorityType) -> bool:
+        """Whether this signal lists the given OpenDRIVE priority semantic."""
+        return priority in self.priorities
+
+    def affects(self, lane: Lane) -> bool:
+        """Whether this signal applies to ``lane``.
+
+        Uses OpenDRIVE ``validity`` when present, then ``orientation`` against
+        whether the lane travels with the road (+s). A validity range that
+        matches no driving lane (CARLA's ``0–0``) is ignored; those files
+        encode lamp facing, so a junction-contact light then applies only to
+        the arriving side, not the road you turn into.
+        """
+        validity_is_dummy = False
+        if self.validity is not None:
+            lo, hi = min(self.validity), max(self.validity)
+
+            def validity_hits(candidate):
+                return any(lo <= sec.openDriveID <= hi for sec in candidate.sections)
+
+            validity_hits_lane = validity_hits(lane)
+            if not validity_hits_lane:
+                road = lane.road
+                if road is not None:
+                    validity_is_dummy = not any(
+                        validity_hits(other) for other in road.lanes
+                    )
+                else:
+                    validity_is_dummy = lo == 0 and hi == 0
+            if not validity_is_dummy and not validity_hits_lane:
+                return False
+        if validity_is_dummy:
+            # CARLA 0–0 is not a lane range; orientation is lamp facing.
+            # Junction-contact lights still only apply to the arriving side.
+            return self._lane_arrives_at_halt(lane)
+        if self.orientation in (None, "none"):
+            return True
+        is_forward = any(sec.isForward for sec in lane.sections)
+        if self.orientation == "+":
+            return is_forward
+        if self.orientation == "-":
+            return not is_forward
+        return True
+
+    def _isHaltLocation(self) -> bool:
+        return (
+            self.isStop
+            or self.isYield
+            or self.isStopLine
+            or self.isWaitingLine
+            or self.isKeepClearLine
+        )
+
+    def resolveStoppingS(self, by_id, plus_contact, minus_contact):
+        """Pick the halt station from references, logical ``s``, or junction contact.
+
+        ``by_id`` maps OpenDRIVE signal id → `Signal` on the same road.
+        ``plus_contact`` / ``minus_contact`` are that road's junction stations
+        for +s / −s travel, or ``None`` if that end is not a junction.
+        """
+        for link in self.references:
+            if link.elementType != "signal":
+                continue
+            target = by_id.get(link.elementId)
+            if target is None:
+                continue
+            kind = (link.type or "").replace("_", "").lower()
+            if kind == "stopline" or target._isHaltLocation():
+                return target.s
+        if self.sIsLogical or self._isHaltLocation():
+            return self.s
+        if self.isTrafficLight:
+            candidates = [
+                contact
+                for contact in (plus_contact, minus_contact)
+                if contact is not None
+            ]
+            if not candidates:
+                return None
+            # CARLA poles sit next to the junction they serve; orientation
+            # often names the other end (or a non-junction end).
+            if self.s is not None:
+                return min(candidates, key=lambda contact: abs(contact - self.s))
+            if self.orientation == "+":
+                return plus_contact
+            if self.orientation == "-":
+                return minus_contact
+            return candidates[0]
+        return None
+
+    def _lane_arrives_at_halt(self, lane: Lane) -> bool:
+        """Whether ``lane`` is still traveling into a junction-contact halt."""
+        road = lane.road
+        if road is None or self.stoppingS is None:
+            return True
+        if not self.isTrafficLight or self.sIsLogical or self._isHaltLocation():
+            return True
+        for link in self.references:
+            if link.elementType == "signal":
+                kind = (link.type or "").replace("_", "").lower()
+                if kind == "stopline":
+                    return True
+        length = road.centerline.length
+        s = self.stoppingS
+        if abs(s) > 1e-4 and abs(s - length) > 1e-4:
+            return True
+        is_forward = any(sec.isForward for sec in lane.sections)
+        at_start = abs(self.stoppingS) <= 1e-4
+        return (not is_forward) if at_start else is_forward
+
+    def stoppingPointOn(self, lane: Lane) -> Optional[Vector]:
+        """Point on ``lane`` where an ego should halt for this signal, if any.
+
+        Takes `stoppingS` along the parent road's +s centerline, then the
+        nearest point on ``lane``. A junction-contact halt is only returned
+        for the direction still arriving at that end — not the lane you enter
+        after turning through the light. ``None`` if the signal does not
+        `affects` the lane, has no `stoppingS`, or does not belong to
+        ``lane.road``.
+        """
+        if self.stoppingS is None or not self.affects(lane):
+            return None
+        road = lane.road
+        if road is None or self not in road.signals:
+            return None
+        if not self._lane_arrives_at_halt(lane):
+            return None
+        length = road.centerline.length
+        if length == 0:
+            return None
+        s = min(max(self.stoppingS, 0.0), length)
+        return lane.centerline.project(road.centerline.pointAlongBy(s))
 
     @property
     def isTrafficLight(self) -> bool:
-        """Whether or not this signal is a traffic light."""
+        """Whether this signal is a traffic light."""
+        if self.priorities:
+            return self.hasPriority(SignalPriorityType.TRAFFIC_LIGHT)
         return self.type == "1000001"
+
+    @property
+    def isStop(self) -> bool:
+        """Whether this signal is a stop sign."""
+        if self.priorities:
+            return self.hasPriority(SignalPriorityType.STOP)
+        return self.type == "206"
+
+    @property
+    def isYield(self) -> bool:
+        """Whether this signal is a yield sign."""
+        if self.priorities:
+            return self.hasPriority(SignalPriorityType.YIELD)
+        return self.type == "205"
+
+    @property
+    def isStopLine(self) -> bool:
+        """Whether this signal marks a stop line."""
+        return self.hasPriority(SignalPriorityType.STOP_LINE)
+
+    @property
+    def isWaitingLine(self) -> bool:
+        """Whether this signal marks a waiting line."""
+        return self.hasPriority(SignalPriorityType.WAITING_LINE)
+
+    @property
+    def isKeepClearLine(self) -> bool:
+        """Whether this signal marks a keep-clear line."""
+        return self.hasPriority(SignalPriorityType.KEEP_CLEAR_LINE)
 
 
 @attr.s(auto_attribs=True, kw_only=True, repr=False, eq=False)

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -906,7 +906,8 @@ class Signal:
     #: May differ from `s` (e.g. a traffic light's pole vs its stop line).
     #: ``None`` if we cannot derive one (typical for a connector-only light).
     stoppingS: Optional[float] = None
-    #: World-space device/pole position from OpenDRIVE ``(s, t)``.
+    #: Placeholder for a future world-space device/pole position. Halt decisions
+    #: intentionally use `stoppingS` and `stoppingPointOn`, not this field.
     position: Optional[Vector] = None
     #: Maneuvers that require this signal to be green (empty if unknown).
     controlledManeuvers: Tuple[Maneuver, ...] = ()

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -332,7 +332,15 @@ class LinearElement(NetworkElement):
     rightEdge: PolylineRegion
 
     # Links to next/previous element
-    _successor: Union[NetworkElement, None] = None  # going forward
+
+    # TO-DO: multiple successors and predecessors are allowed, and can be accessed by index
+    # TO-DO: fix successor and predecessor for sidewalk stuff 
+    # scenic notion is diff from opendrive. predecessor linked to next/prev element, 
+    # with respect to driving direction, opendrive says direction of 
+    # reference line is not exactly the same with traffic
+    # sucessors wil incyde connecting roads and lanes etc, roads to roads, lanes to lanes, etc
+    # tuple of other linear elements of the same type
+    _successor: Union[NetworkElement, None] = None  # going forward (what are all the possible next elements you can end up in when you are at the end of this one)
     _predecessor: Union[NetworkElement, None] = None  # going backward
 
     @property
@@ -393,6 +401,7 @@ class LinearElement(NetworkElement):
         return self.orientation.followFrom(
             _toVector(point), distance, steps=steps, stepSize=stepSize
         )
+    # Signals tuple with singal object in increasing s value, include signal s and stopping line
 
     # Signal entries are ordered by element-local s, which always increases from
     # the start of this element's centerline to its end. For backward lanes this
@@ -406,6 +415,7 @@ class LinearElement(NetworkElement):
 
     #: OpenDRIVE road-s interval covered by this element, if known.
     _roadSRange: Optional[Tuple[float, float]] = None
+    # make them public, and allow to call directly - prob clearer names
     _signalEntries: Tuple[SignalEntry, ...] = ()
     _signalSValues: Tuple[float, ...] = ()
 
@@ -418,39 +428,11 @@ class LinearElement(NetworkElement):
         index = bisect.bisect_left(self._signalSValues, s)
         return list(self._signalEntries[index:])
 
-    # Some OpenDRIVE centerlines contain consecutive duplicate points, producing
-    # zero-length segments. For example, CARLA Town01 road 6 has three such
-    # segments. GEOS/Shapely's line_locate_point can emit a RuntimeWarning and
-    # return NaN when projecting around this degenerate geometry, which would
-    # corrupt signal ordering. This manual projection skips zero-length segments.
     def _projectS(self, point: Vectorlike) -> float:
-        """Project a point to element-local s without relying on GEOS."""
-        point = _toVector(point)
-        best_s = 0.0
-        best_distance = math.inf
-        traversed = 0.0
-        for start, end in self.centerline.segments:
-            dx, dy = end[0] - start[0], end[1] - start[1]
-            length_squared = dx * dx + dy * dy
-            if length_squared == 0:
-                continue
-            fraction = min(
-                1.0,
-                max(
-                    0.0,
-                    ((point.x - start[0]) * dx + (point.y - start[1]) * dy)
-                    / length_squared,
-                ),
-            )
-            projected_x = start[0] + fraction * dx
-            projected_y = start[1] + fraction * dy
-            distance = math.hypot(point.x - projected_x, point.y - projected_y)
-            segment_length = math.sqrt(length_squared)
-            if distance < best_distance:
-                best_distance = distance
-                best_s = traversed + fraction * segment_length
-            traversed += segment_length
-        return best_s
+        """Project a point to element-local s along the centerline."""
+        return self.centerline.lineString.project(
+            geometry.makeShapelyPoint(_toVector(point))
+        )
 
 
 class _ContainsCenterline:
@@ -742,8 +724,6 @@ class Lane(_ContainsCenterline, LinearElement):
         self, position, lookahead: float = 80.0
     ) -> Optional[Tuple[float, float]]:
         """Effective road ``(s, t)`` of the nearest halt ahead of ``position``."""
-        if self.road is None:
-            return None
         lane_line = self.centerline.lineString
         here = lane_line.project(ShapelyPoint(position.x, position.y))
         best_position = None
@@ -999,6 +979,15 @@ class Intersection(NetworkElement):
         return tuple(m.connectingLane.orientation[point] for m in maneuvers)
 
 
+@attr.s(auto_attribs=True, frozen=True)
+class SignalLink:
+    """OpenDRIVE semantic link from a signal to another map element."""
+
+    elementId: str
+    elementType: str
+    type: Optional[str] = None
+
+
 @attr.s(auto_attribs=True, kw_only=True, repr=False, eq=False)
 class Signal:
     """Traffic lights, stop signs, etc.
@@ -1022,6 +1011,8 @@ class Signal:
     priorities: Tuple[Union[SignalPriorityType, str], ...] = ()
     #: Exact OpenDRIVE 1.8+ semantic tag strings.
     tags: FrozenSet[str] = frozenset()
+    #: OpenDRIVE semantic links to stop lines or other map elements.
+    references: Tuple[SignalLink, ...] = ()
     #: Longitudinal s-coordinate along the road reference line (OpenDRIVE ``s``).
     #: Physical pole location in 1.8+; logical effect station if `sIsLogical`.
     s: Optional[float] = None

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -333,6 +333,13 @@ class LinearElement(NetworkElement):
 
     # Links to next/previous element
 
+    # for roads and lanes etc, when you reach the end, there are 
+    # differnt connecting lanes you can go to
+    # successor - the whole intersection
+    # successors (new) - tuple of things of the same type (lanes, if 
+    # one lane goes into 3 lanes)
+    # predecessors is the reverse
+
     # TO-DO: multiple successors and predecessors are allowed, and can be accessed by index
     # TO-DO: fix successor and predecessor for sidewalk stuff 
     # scenic notion is diff from opendrive. predecessor linked to next/prev element, 
@@ -979,15 +986,6 @@ class Intersection(NetworkElement):
         return tuple(m.connectingLane.orientation[point] for m in maneuvers)
 
 
-@attr.s(auto_attribs=True, frozen=True)
-class SignalLink:
-    """OpenDRIVE semantic link from a signal to another map element."""
-
-    elementId: str
-    elementType: str
-    type: Optional[str] = None
-
-
 @attr.s(auto_attribs=True, kw_only=True, repr=False, eq=False)
 class Signal:
     """Traffic lights, stop signs, etc.
@@ -1011,10 +1009,7 @@ class Signal:
     priorities: Tuple[Union[SignalPriorityType, str], ...] = ()
     #: Exact OpenDRIVE 1.8+ semantic tag strings.
     tags: FrozenSet[str] = frozenset()
-    #: OpenDRIVE semantic links to stop lines or other map elements.
-    references: Tuple[SignalLink, ...] = ()
-    #: Longitudinal s-coordinate along the road reference line (OpenDRIVE ``s``).
-    #: Physical pole location in 1.8+; logical effect station if `sIsLogical`.
+    #: Longitudinal station along the parent road used for halt decisions.
     s: Optional[float] = None
     #: Lateral t-coordinate from the reference line (OpenDRIVE ``t``; +t = left).
     t: Optional[float] = None
@@ -1022,9 +1017,6 @@ class Signal:
     orientation: Optional[str] = None
     #: OpenDRIVE ``<validity>`` lane range ``(fromLane, toLane)``, if any.
     validity: Optional[Tuple[int, int]] = None
-    #: True when deprecated ``<positionRoad>`` / ``<positionInertial>`` is present,
-    #: so `s` is the logical effect station rather than the pole.
-    sIsLogical: bool = False
     #: Station along the parent road where an ego should halt for this signal.
     #: May differ from `s` (e.g. a traffic light's pole vs its stop line).
     #: ``None`` if we cannot derive one (typical for a connector-only light).
@@ -1079,13 +1071,9 @@ class Signal:
 
             validity_hits_lane = validity_hits(lane)
             if not validity_hits_lane:
-                road = lane.road
-                if road is not None:
-                    validity_is_dummy = not any(
-                        validity_hits(other) for other in road.lanes
-                    )
-                else:
-                    validity_is_dummy = lo == 0 and hi == 0
+                validity_is_dummy = not any(
+                    validity_hits(other) for other in lane.road.lanes
+                )
             if not validity_is_dummy and not validity_hits_lane:
                 return False
         if validity_is_dummy:
@@ -1104,23 +1092,13 @@ class Signal:
     def _isHaltLocation(self) -> bool:
         return self.isStop or self.isYield
 
-    def resolveStoppingS(self, by_id, plus_contact, minus_contact):
-        """Pick the halt station from references, logical ``s``, or junction contact.
+    def resolveStoppingS(self, plus_contact, minus_contact):
+        """Pick the halt station from this signal's ``s`` or a junction contact.
 
-        ``by_id`` maps OpenDRIVE signal id → `Signal` on the same road.
         ``plus_contact`` / ``minus_contact`` are that road's junction stations
         for +s / −s travel, or ``None`` if that end is not a junction.
         """
-        for link in self.references:
-            if link.elementType != "signal":
-                continue
-            target = by_id.get(link.elementId)
-            if target is None:
-                continue
-            kind = (link.type or "").replace("_", "").lower()
-            if kind == "stopline" or target._isHaltLocation():
-                return target.s
-        if self.sIsLogical or self._isHaltLocation():
+        if self._isHaltLocation():
             return self.s
         if self.isTrafficLight:
             candidates = [
@@ -1142,23 +1120,20 @@ class Signal:
         return None
 
     def _lane_arrives_at_halt(self, lane: Lane) -> bool:
-        """Whether ``lane`` is still traveling into a junction-contact halt."""
+        """Whether ``lane`` is still traveling toward `stoppingS`.
+
+        A mid-road halt applies to every lane that `affects` already accepted.
+        A halt at a road end (``0`` or the reference-line length) is treated as
+        a junction contact: only the direction still arriving at that end is
+        kept, not the lane that has already left through the junction.
+        """
         road = lane.road
-        if road is None or self.stoppingS is None:
-            return True
-        if not self.isTrafficLight or self.sIsLogical or self._isHaltLocation():
-            return True
-        for link in self.references:
-            if link.elementType == "signal":
-                kind = (link.type or "").replace("_", "").lower()
-                if kind == "stopline":
-                    return True
         length = road.centerline.length
         s = self.stoppingS
         if abs(s) > 1e-4 and abs(s - length) > 1e-4:
             return True
         is_forward = any(sec.isForward for sec in lane.sections)
-        at_start = abs(self.stoppingS) <= 1e-4
+        at_start = abs(s) <= 1e-4
         return (not is_forward) if at_start else is_forward
 
     def stoppingPositionOn(self, lane: Lane) -> Optional[Tuple[float, float]]:
@@ -1174,13 +1149,11 @@ class Signal:
         if self.stoppingS is None or not self.affects(lane):
             return None
         road = lane.road
-        if road is None or self not in road.signals:
+        if self not in road.signals:
             return None
         if not self._lane_arrives_at_halt(lane):
             return None
         length = road.centerline.length
-        if length == 0:
-            return None
         s = min(max(self.stoppingS, 0.0), length)
         reference_point = road.centerline.pointAlongBy(s)
         lane_point = lane.centerline.project(reference_point)

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -11,6 +11,7 @@ be created from a map file using :obj:`Network.fromFile`.
 
 from __future__ import annotations  # allow forward references for type annotations
 
+import bisect
 import enum
 import gzip
 import hashlib
@@ -22,7 +23,7 @@ import pathlib
 import pickle
 import struct
 import time
-from typing import FrozenSet, List, Optional, Sequence, Tuple, Union
+from typing import Dict, FrozenSet, List, Optional, Sequence, Tuple, Union
 import weakref
 
 import attr
@@ -149,30 +150,24 @@ class ManeuverType(enum.Enum):
 
 @enum.unique
 class SignalPriorityType(enum.Enum):
-    """OpenDRIVE ``e_signals_semantics_priority`` literals."""
+    """Broad behavioral categories for OpenDRIVE signal priorities."""
 
-    FOUR_WAY = "4way"
-    KEEP_CLEAR_LINE = "keepClearLine"
-    NO_PARKING_LINE = "noParkingLine"
-    NO_TURN_ON_RED = "noTurnOnRed"
-    PRIORITY_ROAD_END = "priorityRoadEnd"
-    PRIORITY_ROAD = "priorityRoad"
-    PRIORITY_TO_THE_RIGHT_RULE = "priorityToTheRightRule"
-    STOP_LINE = "stopLine"
     STOP = "stop"
-    TRAFFIC_LIGHT = "trafficLight"
-    TURN_ON_RED_ALLOWED = "turnOnRedAllowed"
-    WAITING_LINE = "waitingLine"
     YIELD = "yield"
-    UNKNOWN = "unknown"
+    TRAFFIC_LIGHT = "trafficLight"
 
     @classmethod
-    def fromOpenDrive(cls, type_str: str) -> SignalPriorityType:
-        """Map an OpenDRIVE priority string to an enum member."""
-        for member in cls:
-            if member is not cls.UNKNOWN and member.value == type_str:
-                return member
-        return cls.UNKNOWN
+    def fromOpenDrive(cls, type_str: str) -> Union[SignalPriorityType, str]:
+        """Categorize a priority, preserving uncategorized details as strings."""
+        categories = {
+            "4way": cls.STOP,
+            "stop": cls.STOP,
+            "stopLine": cls.STOP,
+            "yield": cls.YIELD,
+            "trafficLight": cls.TRAFFIC_LIGHT,
+            "turnOnRedAllowed": cls.TRAFFIC_LIGHT,
+        }
+        return categories.get(type_str, type_str)
 
 
 @attr.s(auto_attribs=True, kw_only=True, eq=False)
@@ -398,6 +393,64 @@ class LinearElement(NetworkElement):
             _toVector(point), distance, steps=steps, stepSize=stepSize
         )
 
+    # Signal entries are ordered by element-local s, which always increases from
+    # the start of this element's centerline to its end. For backward lanes this
+    # is travel order, the reverse of OpenDRIVE road-s order.
+    SignalEntry = Tuple[
+         float,   # element-local s, used for ordering and bisect
+         "Signal",  # controlling signal
+         float,   # OpenDRIVE road s of the effective stopping position
+         float,   # OpenDRIVE road t at this element's centerline
+    ]
+
+    #: OpenDRIVE road-s interval covered by this element, if known.
+    _roadSRange: Optional[Tuple[float, float]] = None
+    _signalEntries: Tuple[SignalEntry, ...] = ()
+    _signalSValues: Tuple[float, ...] = ()
+
+    def signalLookup(self) -> Tuple[List[SignalEntry], List[float]]:
+        """Return signal entries and their parallel, increasing local-s index."""
+        return list(self._signalEntries), list(self._signalSValues)
+
+    def signalsAhead(self, s: float) -> List[SignalEntry]:
+        """Return all signals at or after local ``s`` in travel order."""
+        index = bisect.bisect_left(self._signalSValues, s)
+        return list(self._signalEntries[index:])
+
+    # Some OpenDRIVE centerlines contain consecutive duplicate points, producing
+    # zero-length segments. For example, CARLA Town01 road 6 has three such
+    # segments. GEOS/Shapely's line_locate_point can emit a RuntimeWarning and
+    # return NaN when projecting around this degenerate geometry, which would
+    # corrupt signal ordering. This manual projection skips zero-length segments.
+    def _projectS(self, point: Vectorlike) -> float:
+        """Project a point to element-local s without relying on GEOS."""
+        point = _toVector(point)
+        best_s = 0.0
+        best_distance = math.inf
+        traversed = 0.0
+        for start, end in self.centerline.segments:
+            dx, dy = end[0] - start[0], end[1] - start[1]
+            length_squared = dx * dx + dy * dy
+            if length_squared == 0:
+                continue
+            fraction = min(
+                1.0,
+                max(
+                    0.0,
+                    ((point.x - start[0]) * dx + (point.y - start[1]) * dy)
+                    / length_squared,
+                ),
+            )
+            projected_x = start[0] + fraction * dx
+            projected_y = start[1] + fraction * dy
+            distance = math.hypot(point.x - projected_x, point.y - projected_y)
+            segment_length = math.sqrt(length_squared)
+            if distance < best_distance:
+                best_distance = distance
+                best_s = traversed + fraction * segment_length
+            traversed += segment_length
+        return best_s
+
 
 class _ContainsCenterline:
     """Mixin which asserts that the centerline is contained in the polygon.
@@ -471,6 +524,91 @@ class Road(LinearElement):
         self.laneGroups = tuple(lgs)
         self.sidewalks = tuple(sidewalks)
         self.sidewalkRegion = PolygonalRegion.unionAll(sidewalks)
+
+    def _lateralOffsetAt(self, s: float, point: Vectorlike) -> float:
+        """Signed lateral offset of ``point`` from the reference line at ``s``."""
+        point = _toVector(point)
+        reference_point = self.centerline.pointAlongBy(s)
+        index = bisect.bisect_left(self.centerline.cumulativeLengths, s)
+        index = min(index, len(self.centerline.segments) - 1)
+        start, end = self.centerline.segments[index]
+        tangent_x, tangent_y = end[0] - start[0], end[1] - start[1]
+        offset_x = point.x - reference_point.x
+        offset_y = point.y - reference_point.y
+        distance = math.hypot(offset_x, offset_y)
+        cross = tangent_x * offset_y - tangent_y * offset_x
+        return distance if cross >= 0 else -distance
+
+    def _propagateSignals(self):
+        """Populate signal lookups on this road and its lane hierarchy."""
+        tolerance = 1e-6
+        pending = {}
+        elements = [self, *self.sections, *self.laneGroups, *self.lanes]
+        elements.extend(section for lane in self.lanes for section in lane.sections)
+        for element in elements:
+            element._signalEntries = ()
+            element._signalSValues = ()
+
+        road_section_for_lane_section = {
+            lane_section: road_section
+            for road_section in self.sections
+            for lane_section in road_section.lanes
+        }
+
+        def add(element, signal, road_s):
+            if element is None or element._roadSRange is None:
+                return
+            road_lo, road_hi = element._roadSRange
+            if not road_lo - tolerance <= road_s <= road_hi + tolerance:
+                return
+            reference_point = self.centerline.pointAlongBy(road_s)
+            if element is self:
+                element_point = reference_point
+                local_s = road_s
+                road_t = 0.0
+            else:
+                element_point = element.centerline.project(reference_point)
+                local_s = element._projectS(element_point)
+                road_t = self._lateralOffsetAt(road_s, element_point)
+            pending.setdefault(element, []).append((local_s, signal, road_s, road_t))
+
+        for signal in self.signals:
+            if signal.stoppingS is None:
+                continue
+            road_s = min(max(signal.stoppingS, 0.0), self.centerline.length)
+            add(self, signal, road_s)
+
+            for lane in self.lanes:
+                if not signal.affects(lane) or not signal._lane_arrives_at_halt(lane):
+                    continue
+                effective_s = road_s
+                add(lane, signal, effective_s)
+                add(lane.group, signal, effective_s)
+
+                matching_sections = [
+                    section
+                    for section in lane.sections
+                    if section._roadSRange is not None
+                    and section._roadSRange[0] - tolerance
+                    <= effective_s
+                    <= section._roadSRange[1] + tolerance
+                ]
+                if matching_sections:
+                    lane_section = matching_sections[0]
+                    add(lane_section, signal, effective_s)
+                    add(
+                        road_section_for_lane_section[lane_section],
+                        signal,
+                        effective_s,
+                    )
+
+        for element, entries in pending.items():
+            unique = {}
+            for entry in entries:
+                unique[(entry[1].uid, entry[2])] = entry
+            ordered = sorted(unique.values(), key=lambda entry: (entry[0], entry[1].uid))
+            element._signalEntries = tuple(ordered)
+            element._signalSValues = tuple(entry[0] for entry in ordered)
 
     def _defaultHeadingAt(self, point):
         point = _toVector(point)
@@ -599,21 +737,28 @@ class Lane(_ContainsCenterline, LinearElement):
         """Get the LaneSection passing through a given point."""
         return self.network.findPointIn(point, self.sections, reject)
 
-    def haltPointAhead(self, position, lookahead: float = 80.0) -> Optional[Vector]:
-        """Nearest `Signal.stoppingPointOn` this lane still ahead of ``position``."""
+    def haltPositionAhead(
+        self, position, lookahead: float = 80.0
+    ) -> Optional[Tuple[float, float]]:
+        """Effective road ``(s, t)`` of the nearest halt ahead of ``position``."""
         if self.road is None:
             return None
-        here = self.centerline.lineString.project(ShapelyPoint(position.x, position.y))
-        best = None
+        lane_line = self.centerline.lineString
+        here = lane_line.project(ShapelyPoint(position.x, position.y))
+        best_position = None
         best_ahead = None
         for sig in self.road.signals:
-            pt = sig.stoppingPointOn(self)
-            if pt is None:
+            stop_position = sig.stoppingPositionOn(self)
+            if stop_position is None:
                 continue
-            ahead = self.centerline.lineString.project(ShapelyPoint(pt.x, pt.y)) - here
+            s, _ = stop_position
+            reference_point = self.road.centerline.pointAlongBy(s)
+            pt = self.centerline.project(reference_point)
+            ahead = lane_line.project(ShapelyPoint(pt.x, pt.y)) - here
             if 0 <= ahead <= lookahead and (best_ahead is None or ahead < best_ahead):
-                best, best_ahead = pt, ahead
-        return best
+                best_position = stop_position
+                best_ahead = ahead
+        return best_position
 
 
 @attr.s(auto_attribs=True, kw_only=True, repr=False, eq=False)
@@ -853,20 +998,6 @@ class Intersection(NetworkElement):
         return tuple(m.connectingLane.orientation[point] for m in maneuvers)
 
 
-@attr.s(auto_attribs=True, frozen=True, kw_only=True)
-class SignalLink:
-    """OpenDRIVE ``<reference>`` from this signal to another signal or object.
-
-    Distinct from ``<signalReference>``, which re-applies the same signal on
-    another road. A typical 1.8+ use is a traffic light linking to a stop line
-    (``elementType="signal"``, ``type="stopline"``).
-    """
-
-    elementId: str
-    elementType: str
-    type: Optional[str] = None
-
-
 @attr.s(auto_attribs=True, kw_only=True, repr=False, eq=False)
 class Signal:
     """Traffic lights, stop signs, etc.
@@ -885,9 +1016,9 @@ class Signal:
     type: str
     #: Subtype identifier according to country code (``None`` if absent).
     subtype: Optional[str] = None
-    #: OpenDRIVE ``e_signals_semantics_priority`` entries (empty if unknown / pre-1.8).
-    #: All ``<priority>`` children are kept; they are not collapsed to a single type.
-    priorities: Tuple[SignalPriorityType, ...] = ()
+    #: Broad category or original OpenDRIVE string for each ``<priority>`` entry.
+    #: Empty for signals without 1.8+ priority semantics.
+    priorities: Tuple[Union[SignalPriorityType, str], ...] = ()
     #: Longitudinal s-coordinate along the road reference line (OpenDRIVE ``s``).
     #: Physical pole location in 1.8+; logical effect station if `sIsLogical`.
     s: Optional[float] = None
@@ -897,8 +1028,6 @@ class Signal:
     orientation: Optional[str] = None
     #: OpenDRIVE ``<validity>`` lane range ``(fromLane, toLane)``, if any.
     validity: Optional[Tuple[int, int]] = None
-    #: OpenDRIVE ``<reference>`` links (e.g. light → stop line).
-    references: Tuple[SignalLink, ...] = ()
     #: True when deprecated ``<positionRoad>`` / ``<positionInertial>`` is present,
     #: so `s` is the logical effect station rather than the pole.
     sIsLogical: bool = False
@@ -907,7 +1036,7 @@ class Signal:
     #: ``None`` if we cannot derive one (typical for a connector-only light).
     stoppingS: Optional[float] = None
     #: Placeholder for a future world-space device/pole position. Halt decisions
-    #: intentionally use `stoppingS` and `stoppingPointOn`, not this field.
+    #: intentionally use `stoppingS` and `stoppingPositionOn`, not this field.
     position: Optional[Vector] = None
     #: Maneuvers that require this signal to be green (empty if unknown).
     controlledManeuvers: Tuple[Maneuver, ...] = ()
@@ -957,13 +1086,7 @@ class Signal:
         return True
 
     def _isHaltLocation(self) -> bool:
-        return (
-            self.isStop
-            or self.isYield
-            or self.isStopLine
-            or self.isWaitingLine
-            or self.isKeepClearLine
-        )
+        return self.isStop or self.isYield
 
     def resolveStoppingS(self, by_id, plus_contact, minus_contact):
         """Pick the halt station from references, logical ``s``, or junction contact.
@@ -1022,15 +1145,15 @@ class Signal:
         at_start = abs(self.stoppingS) <= 1e-4
         return (not is_forward) if at_start else is_forward
 
-    def stoppingPointOn(self, lane: Lane) -> Optional[Vector]:
-        """Point on ``lane`` where an ego should halt for this signal, if any.
+    def stoppingPositionOn(self, lane: Lane) -> Optional[Tuple[float, float]]:
+        """Effective road ``(s, t)`` where an ego should halt on ``lane``.
 
-        Takes `stoppingS` along the parent road's +s centerline, then the
-        nearest point on ``lane``. A junction-contact halt is only returned
-        for the direction still arriving at that end — not the lane you enter
-        after turning through the light. ``None`` if the signal does not
-        `affects` the lane, has no `stoppingS`, or does not belong to
-        ``lane.road``.
+        The returned ``t`` is the signed lateral offset from the road reference
+        line to the lane center at `stoppingS` (positive to the left). A
+        junction-contact halt is only returned for the direction still arriving
+        at that end — not the lane you enter after turning through the light.
+        ``None`` if the signal does not `affects` the lane, has no `stoppingS`,
+        or does not belong to ``lane.road``.
         """
         if self.stoppingS is None or not self.affects(lane):
             return None
@@ -1043,7 +1166,10 @@ class Signal:
         if length == 0:
             return None
         s = min(max(self.stoppingS, 0.0), length)
-        return lane.centerline.project(road.centerline.pointAlongBy(s))
+        reference_point = road.centerline.pointAlongBy(s)
+        lane_point = lane.centerline.project(reference_point)
+        t = road._lateralOffsetAt(s, lane_point)
+        return s, t
 
     @property
     def isTrafficLight(self) -> bool:
@@ -1065,21 +1191,6 @@ class Signal:
         if self.priorities:
             return self.hasPriority(SignalPriorityType.YIELD)
         return self.type == "205"
-
-    @property
-    def isStopLine(self) -> bool:
-        """Whether this signal marks a stop line."""
-        return self.hasPriority(SignalPriorityType.STOP_LINE)
-
-    @property
-    def isWaitingLine(self) -> bool:
-        """Whether this signal marks a waiting line."""
-        return self.hasPriority(SignalPriorityType.WAITING_LINE)
-
-    @property
-    def isKeepClearLine(self) -> bool:
-        """Whether this signal marks a keep-clear line."""
-        return self.hasPriority(SignalPriorityType.KEEP_CLEAR_LINE)
 
 
 @attr.s(auto_attribs=True, kw_only=True, repr=False, eq=False)
@@ -1237,7 +1348,7 @@ class Network:
 
         :meta private:
         """
-        return 35
+        return 36
 
     class DigestMismatchError(Exception):
         """Exception raised when loading a cached map not matching the original file."""

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -331,8 +331,6 @@ class LinearElement(NetworkElement):
     leftEdge: PolylineRegion
     rightEdge: PolylineRegion
 
-    # Links to next/previous element
-
     # for roads and lanes etc, when you reach the end, there are 
     # differnt connecting lanes you can go to
     # successor - the whole intersection
@@ -347,8 +345,13 @@ class LinearElement(NetworkElement):
     # reference line is not exactly the same with traffic
     # sucessors wil incyde connecting roads and lanes etc, roads to roads, lanes to lanes, etc
     # tuple of other linear elements of the same type
+
+    # Links to next/previous element
     _successor: Union[NetworkElement, None] = None  # going forward (what are all the possible next elements you can end up in when you are at the end of this one)
     _predecessor: Union[NetworkElement, None] = None  # going backward
+
+    _successors: Tuple[LinearElement, ...] = ()
+    _predecessors: Tuple[LinearElement, ...] = ()
 
     @property
     def successor(self):
@@ -357,6 +360,28 @@ class LinearElement(NetworkElement):
     @property
     def predecessor(self):
         return _rejectIfNonexistent(self._predecessor, "predecessor")
+
+    @property
+    def successors(self) -> Tuple[LinearElement, ...]:
+        return self._successors
+
+    @property
+    def predecessors(self) -> Tuple[LinearElement, ...]:
+        return self._predecessors
+
+    def _addSuccessor(self, element):
+        if element is None or type(element) is not type(self):
+            return
+        if element in self._successors:
+            return
+        self._successors += (element,)
+
+    def _addPredecessor(self, element):
+        if element is None or type(element) is not type(self):
+            return
+        if element in self._predecessors:
+            return
+        self._predecessors += (element,)
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -1026,6 +1051,10 @@ class Signal:
     position: Optional[Vector] = None
     #: Maneuvers that require this signal to be green (empty if unknown).
     controlledManeuvers: Tuple[Maneuver, ...] = ()
+    #: Incoming or hosting road this signal belongs to.
+    road: Optional[Tuple[Road, ...]] = None
+    #: Junction this signal controls, if any.
+    intersection: Optional[Intersection] = None
 
     @property
     def country(self) -> str:

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -331,23 +331,25 @@ class LinearElement(NetworkElement):
     leftEdge: PolylineRegion
     rightEdge: PolylineRegion
 
-    # for roads and lanes etc, when you reach the end, there are 
+    # for roads and lanes etc, when you reach the end, there are
     # differnt connecting lanes you can go to
     # successor - the whole intersection
-    # successors (new) - tuple of things of the same type (lanes, if 
+    # successors (new) - tuple of things of the same type (lanes, if
     # one lane goes into 3 lanes)
     # predecessors is the reverse
 
     # TO-DO: multiple successors and predecessors are allowed, and can be accessed by index
-    # TO-DO: fix successor and predecessor for sidewalk stuff 
-    # scenic notion is diff from opendrive. predecessor linked to next/prev element, 
-    # with respect to driving direction, opendrive says direction of 
+    # TO-DO: fix successor and predecessor for sidewalk stuff
+    # scenic notion is diff from opendrive. predecessor linked to next/prev element,
+    # with respect to driving direction, opendrive says direction of
     # reference line is not exactly the same with traffic
     # sucessors wil incyde connecting roads and lanes etc, roads to roads, lanes to lanes, etc
     # tuple of other linear elements of the same type
 
     # Links to next/previous element
-    _successor: Union[NetworkElement, None] = None  # going forward (what are all the possible next elements you can end up in when you are at the end of this one)
+    _successor: Union[NetworkElement, None] = (
+        None  # going forward (what are all the possible next elements you can end up in when you are at the end of this one)
+    )
     _predecessor: Union[NetworkElement, None] = None  # going backward
 
     _successors: Tuple[LinearElement, ...] = ()
@@ -433,6 +435,7 @@ class LinearElement(NetworkElement):
         return self.orientation.followFrom(
             _toVector(point), distance, steps=steps, stepSize=stepSize
         )
+
     # Signals tuple with singal object in increasing s value, include signal s and stopping line
 
     # Signal entries are ordered by element-local s, which always increases from
@@ -1042,7 +1045,7 @@ class Signal:
     orientation: Optional[str] = None
     #: Station along the parent road where an ego should halt for this signal.
     #: May differ from `s` (e.g. a traffic light's pole vs its stop line).
-    #: ``None`` if we cannot derive one (typical for a connector-only light).
+    #: ``None`` if we cannot derive one.
     stoppingS: Optional[float] = None
     #: Placeholder for a future world-space device/pole position. Halt decisions
     #: intentionally use `stoppingS` and `stoppingPositionOn`, not this field.
@@ -1050,7 +1053,7 @@ class Signal:
     #: Maneuvers that require this signal to be green (empty if unknown).
     controlledManeuvers: Tuple[Maneuver, ...] = ()
     #: Incoming or hosting road this signal belongs to.
-    road: Optional[Tuple[Road, ...]] = None
+    road: Optional[Road] = None
     #: Junction this signal controls, if any.
     intersection: Optional[Intersection] = None
 
@@ -1227,6 +1230,8 @@ class Network:
 
     #: All intersections in the network.
     intersections: Tuple[Intersection]
+    #: All traffic signals in the network.
+    signals: Tuple[Signal, ...] = None
     #: All pedestrian crossings in the network.
     crossings: Tuple[PedestrianCrossing]
     #: All sidewalks in the network.
@@ -1267,6 +1272,19 @@ class Network:
         self.allRoads = self.roads + self.connectingRoads
         self.roadSections = tuple(sec for road in self.roads for sec in road.sections)
         self.laneSections = tuple(sec for lane in self.lanes for sec in lane.sections)
+
+        ordered, seen = [], set()
+        for road in self.roads:
+            for signal in road.signals:
+                if id(signal) not in seen:
+                    ordered.append(signal)
+                    seen.add(id(signal))
+        for intersection in self.intersections:
+            for signal in intersection.signals:
+                if id(signal) not in seen:
+                    ordered.append(signal)
+                    seen.add(id(signal))
+        self.signals = tuple(ordered)
 
         if self.roadRegion is None:
             self.roadRegion = PolygonalRegion.unionAll(self.roads)
@@ -1353,7 +1371,7 @@ class Network:
 
         :meta private:
         """
-        return 37
+        return 38
 
     class DigestMismatchError(Exception):
         """Exception raised when loading a cached map not matching the original file."""

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -332,7 +332,7 @@ class LinearElement(NetworkElement):
     rightEdge: PolylineRegion
 
     # Links to next/previous element
-    _successor: Union[NetworkElement, None] = None # going forward
+    _successor: Union[NetworkElement, None] = None  # going forward
     _predecessor: Union[NetworkElement, None] = None  # going backward
 
     _successors: Tuple[LinearElement, ...] = ()

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -1040,8 +1040,6 @@ class Signal:
     t: Optional[float] = None
     #: OpenDRIVE signal orientation: ``"+"``, ``"-"``, or ``"none"``.
     orientation: Optional[str] = None
-    #: OpenDRIVE ``<validity>`` lane range ``(fromLane, toLane)``, if any.
-    validity: Optional[Tuple[int, int]] = None
     #: Station along the parent road where an ego should halt for this signal.
     #: May differ from `s` (e.g. a traffic light's pole vs its stop line).
     #: ``None`` if we cannot derive one (typical for a connector-only light).
@@ -1085,29 +1083,12 @@ class Signal:
     def affects(self, lane: Lane) -> bool:
         """Whether this signal applies to ``lane``.
 
-        Uses OpenDRIVE ``validity`` when present, then ``orientation`` against
-        whether the lane travels with the road (+s). A validity range that
-        matches no driving lane (CARLA's ``0–0``) is ignored; those files
-        encode lamp facing, so a junction-contact light then applies only to
-        the arriving side, not the road you turn into.
+        A halt at a road end is treated as a junction contact: only the
+        arriving direction is kept, because device orientation is often lamp
+        facing rather than traffic. Otherwise ``orientation`` is compared to
+        whether the lane travels with the road (+s).
         """
-        validity_is_dummy = False
-        if self.validity is not None:
-            lo, hi = min(self.validity), max(self.validity)
-
-            def validity_hits(candidate):
-                return any(lo <= sec.openDriveID <= hi for sec in candidate.sections)
-
-            validity_hits_lane = validity_hits(lane)
-            if not validity_hits_lane:
-                validity_is_dummy = not any(
-                    validity_hits(other) for other in lane.road.lanes
-                )
-            if not validity_is_dummy and not validity_hits_lane:
-                return False
-        if validity_is_dummy:
-            # CARLA 0–0 is not a lane range; orientation is lamp facing.
-            # Junction-contact lights still only apply to the arriving side.
+        if self._halts_at_road_end(lane.road):
             return self._lane_arrives_at_halt(lane)
         if self.orientation in (None, "none"):
             return True
@@ -1117,6 +1098,13 @@ class Signal:
         if self.orientation == "-":
             return not is_forward
         return True
+
+    def _halts_at_road_end(self, road: Optional[Road]) -> bool:
+        if road is None or self.stoppingS is None:
+            return False
+        length = road.centerline.length
+        s = self.stoppingS
+        return abs(s) <= 1e-4 or abs(s - length) <= 1e-4
 
     def _isHaltLocation(self) -> bool:
         return self.isStop or self.isYield
@@ -1157,9 +1145,8 @@ class Signal:
         kept, not the lane that has already left through the junction.
         """
         road = lane.road
-        length = road.centerline.length
         s = self.stoppingS
-        if abs(s) > 1e-4 and abs(s - length) > 1e-4:
+        if not self._halts_at_road_end(road):
             return True
         is_forward = any(sec.isForward for sec in lane.sections)
         at_start = abs(s) <= 1e-4

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -331,25 +331,8 @@ class LinearElement(NetworkElement):
     leftEdge: PolylineRegion
     rightEdge: PolylineRegion
 
-    # for roads and lanes etc, when you reach the end, there are
-    # differnt connecting lanes you can go to
-    # successor - the whole intersection
-    # successors (new) - tuple of things of the same type (lanes, if
-    # one lane goes into 3 lanes)
-    # predecessors is the reverse
-
-    # TO-DO: multiple successors and predecessors are allowed, and can be accessed by index
-    # TO-DO: fix successor and predecessor for sidewalk stuff
-    # scenic notion is diff from opendrive. predecessor linked to next/prev element,
-    # with respect to driving direction, opendrive says direction of
-    # reference line is not exactly the same with traffic
-    # sucessors wil incyde connecting roads and lanes etc, roads to roads, lanes to lanes, etc
-    # tuple of other linear elements of the same type
-
     # Links to next/previous element
-    _successor: Union[NetworkElement, None] = (
-        None  # going forward (what are all the possible next elements you can end up in when you are at the end of this one)
-    )
+    _successor: Union[NetworkElement, None] = None # going forward
     _predecessor: Union[NetworkElement, None] = None  # going backward
 
     _successors: Tuple[LinearElement, ...] = ()

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -773,10 +773,16 @@ class Road:
         last_section = None
         forwardSidewalks, backwardSidewalks = [], []
         forwardShoulders, backwardShoulders = [], []
-        for sec, pts, sec_poly, lane_polys in zip(
-            self.lane_secs, self.sec_points, self.sec_polys, self.sec_lane_polys
+        section_ends = [sec.s0 for sec in self.lane_secs[1:]] + [self.length]
+        for sec, section_end, pts, sec_poly, lane_polys in zip(
+            self.lane_secs,
+            section_ends,
+            self.sec_points,
+            self.sec_polys,
+            self.sec_lane_polys,
         ):
             pts = [pt[:2] for pt in pts]  # drop s coordinate
+            road_s_range = (sec.s0, section_end)
             assert sec.drivable_lanes
             laneSections = {}
             for id_, lane in sec.drivable_lanes.items():
@@ -809,6 +815,7 @@ class Road:
                     road=None,
                     openDriveID=id_,
                     isForward=id_ < 0,
+                    roadSRange=road_s_range,
                 )
                 section._original_lane = lane
                 laneSections[id_] = section
@@ -823,6 +830,7 @@ class Road:
                 predecessor=last_section,
                 road=None,  # will set later
                 lanesByOpenDriveID=laneSections,
+                roadSRange=road_s_range,
             )
             roadSections.append(section)
             allElements.append(section)
@@ -1068,6 +1076,10 @@ class Road:
                         road=None,
                         sections=tuple(sections),
                         successor=successorLane,  # will correct inter-road links later
+                        roadSRange=(
+                            min(section._roadSRange[0] for section in sections),
+                            max(section._roadSRange[1] for section in sections),
+                        ),
                     )
                     nextID += 1
                     for section in sections:
@@ -1128,6 +1140,10 @@ class Road:
                 bikeLane=None,
                 shoulder=forwardShoulder,
                 opposite=None,
+                roadSRange=(
+                    min(lane._roadSRange[0] for lane in forwardLanes),
+                    max(lane._roadSRange[1] for lane in forwardLanes),
+                ),
             )
             allElements.append(forwardGroup)
         else:
@@ -1149,6 +1165,10 @@ class Road:
                 bikeLane=None,
                 shoulder=backwardShoulder,
                 opposite=forwardGroup,
+                roadSRange=(
+                    min(lane._roadSRange[0] for lane in backwardLanes),
+                    max(lane._roadSRange[1] for lane in backwardLanes),
+                ),
             )
             allElements.append(backwardGroup)
             if forwardGroup:
@@ -1174,7 +1194,7 @@ class Road:
                 references=signal_.references,
                 sIsLogical=signal_.sIsLogical,
                 # Placeholder: physical pole coordinates are not needed for halt
-                # decisions, which use stoppingS and stoppingPointOn instead.
+                # decisions, which use stoppingS and stoppingPositionOn instead.
                 position=None,
             )
             roadSignals.append(signal)
@@ -1210,6 +1230,7 @@ class Road:
             sections=roadSections,
             signals=tuple(roadSignals),
             crossings=(),  # TODO add these!
+            roadSRange=(0.0, self.length),
         )
         allElements.append(road)
 
@@ -1244,6 +1265,8 @@ class Road:
                 sec.group = backwardGroup
                 sec.road = road
                 del sec._original_lane
+
+        road._propagateSignals()
 
         return road, allElements
 
@@ -1512,7 +1535,10 @@ class RoadMap:
         """Warn if a known legacy ``type`` conflicts with ``<priority>`` semantics."""
         legacy = self._LEGACY_TYPE_TO_PRIORITY.get(signal.type_)
         if legacy is not None and signal.priorities and legacy not in signal.priorities:
-            listed = ", ".join(p.value for p in signal.priorities)
+            listed = ", ".join(
+                p.value if isinstance(p, roadDomain.SignalPriorityType) else p
+                for p in signal.priorities
+            )
             warn(
                 f'signal {signal.id_} has OpenDRIVE type "{signal.type_}" '
                 f"(legacy {legacy.value}) but <priority> lists [{listed}]; "
@@ -1522,9 +1548,10 @@ class RoadMap:
     def __parse_signal_priorities(self, signal_elem):
         """Parse ``<semantics><priority type="…"/>`` children (OpenDRIVE 1.8+).
 
-        Returns a tuple of `roadDomain.SignalPriorityType`. Unknown literals are
-        mapped to `UNKNOWN` and emit an `OpenDriveWarning`. Other semantic
-        categories (``<speed>``, ``<lane>``, …) are ignored for now.
+        Stop, yield, and traffic-light literals are mapped to broad
+        `roadDomain.SignalPriorityType` categories. Other literals are retained
+        verbatim as strings. Other semantic categories (``<speed>``, ``<lane>``,
+        …) are ignored for now.
         """
         semantics_elem = signal_elem.find("semantics")
         if semantics_elem is None:
@@ -1538,13 +1565,7 @@ class RoadMap:
                     "skipping it"
                 )
                 continue
-            priority = roadDomain.SignalPriorityType.fromOpenDrive(type_str)
-            if priority is roadDomain.SignalPriorityType.UNKNOWN:
-                warn(
-                    f'signal {signal_elem.get("id")} has unrecognized '
-                    f'priority type "{type_str}"; storing as UNKNOWN'
-                )
-            priorities.append(priority)
+            priorities.append(roadDomain.SignalPriorityType.fromOpenDrive(type_str))
         return tuple(priorities)
 
     def __parse_signal_links(self, signal_elem):

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -1216,7 +1216,7 @@ class Road:
             leftEdge = backwardGroup.rightEdge
         else:
             leftEdge = forwardGroup.leftEdge
-        centerline = PolylineRegion(tuple(pt[:2] for pt in self.ref_line_points))
+        centerline = PolylineRegion(cleanChain(tuple(pt[:2] for pt in self.ref_line_points)))
         road = roadDomain.Road(
             name=self.name,
             uid=f"road{self.id_}",  # need prefix to prevent collisions with intersections

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -419,46 +419,6 @@ class Road:
 
         self.remappedStartLanes = None  # hack for handling spurious initial lane sections
 
-    def st_to_xy(self, s, t=0.0):
-        """OpenDRIVE ``(s, t)`` → inertial ``(x, y)`` on this road.
-
-        Interpolates the sampled reference line (same points as the domain
-        centerline). ``+t`` is left of +s. ``None`` if geometry is not ready.
-        """
-        pts = getattr(self, "ref_line_points", None)
-        if not pts:
-            return None
-        s = float(s)
-        t = float(t)
-        if s <= pts[0][2]:
-            i = 0
-        elif s >= pts[-1][2]:
-            i = max(len(pts) - 2, 0)
-        else:
-            i = 0
-            for j in range(len(pts) - 1):
-                if pts[j][2] <= s <= pts[j + 1][2]:
-                    i = j
-                    break
-        if i + 1 >= len(pts):
-            return (pts[-1][0], pts[-1][1])
-        p0, p1 = pts[i], pts[i + 1]
-        ds = p1[2] - p0[2]
-        if abs(ds) < 1e-12:
-            x, y = p0[0], p0[1]
-            dx, dy = p1[0] - p0[0], p1[1] - p0[1]
-        else:
-            a = (s - p0[2]) / ds
-            x = p0[0] + a * (p1[0] - p0[0])
-            y = p0[1] + a * (p1[1] - p0[1])
-            dx, dy = p1[0] - p0[0], p1[1] - p0[1]
-        if t == 0.0:
-            return (x, y)
-        n = math.hypot(dx, dy)
-        if n < 1e-12:
-            return (x, y)
-        return (x + t * (-dy / n), y + t * (dx / n))
-
     def get_ref_line_offset(self, s):
         if not self.offset:
             return 0
@@ -1200,7 +1160,6 @@ class Road:
         roadSignals = []
         for i, signal_ in enumerate(self.signals):
             validity = None if signal_.validity is None else tuple(signal_.validity)
-            xy = self.st_to_xy(signal_.s, signal_.t)
             signal = roadDomain.Signal(
                 uid=f"signal{signal_.id_}_{self.id_}_{i}",
                 openDriveID=signal_.id_,
@@ -1214,7 +1173,9 @@ class Road:
                 validity=validity,
                 references=signal_.references,
                 sIsLogical=signal_.sIsLogical,
-                position=Vector(*xy) if xy else None,
+                # Placeholder: physical pole coordinates are not needed for halt
+                # decisions, which use stoppingS and stoppingPointOn instead.
+                position=None,
             )
             roadSignals.append(signal)
 

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -419,6 +419,46 @@ class Road:
 
         self.remappedStartLanes = None  # hack for handling spurious initial lane sections
 
+    def st_to_xy(self, s, t=0.0):
+        """OpenDRIVE ``(s, t)`` → inertial ``(x, y)`` on this road.
+
+        Interpolates the sampled reference line (same points as the domain
+        centerline). ``+t`` is left of +s. ``None`` if geometry is not ready.
+        """
+        pts = getattr(self, "ref_line_points", None)
+        if not pts:
+            return None
+        s = float(s)
+        t = float(t)
+        if s <= pts[0][2]:
+            i = 0
+        elif s >= pts[-1][2]:
+            i = max(len(pts) - 2, 0)
+        else:
+            i = 0
+            for j in range(len(pts) - 1):
+                if pts[j][2] <= s <= pts[j + 1][2]:
+                    i = j
+                    break
+        if i + 1 >= len(pts):
+            return (pts[-1][0], pts[-1][1])
+        p0, p1 = pts[i], pts[i + 1]
+        ds = p1[2] - p0[2]
+        if abs(ds) < 1e-12:
+            x, y = p0[0], p0[1]
+            dx, dy = p1[0] - p0[0], p1[1] - p0[1]
+        else:
+            a = (s - p0[2]) / ds
+            x = p0[0] + a * (p1[0] - p0[0])
+            y = p0[1] + a * (p1[1] - p0[1])
+            dx, dy = p1[0] - p0[0], p1[1] - p0[1]
+        if t == 0.0:
+            return (x, y)
+        n = math.hypot(dx, dy)
+        if n < 1e-12:
+            return (x, y)
+        return (x + t * (-dy / n), y + t * (dx / n))
+
     def get_ref_line_offset(self, s):
         if not self.offset:
             return 0
@@ -1159,13 +1199,30 @@ class Road:
         # Create signal
         roadSignals = []
         for i, signal_ in enumerate(self.signals):
+            validity = None if signal_.validity is None else tuple(signal_.validity)
+            xy = self.st_to_xy(signal_.s, signal_.t)
             signal = roadDomain.Signal(
                 uid=f"signal{signal_.id_}_{self.id_}_{i}",
                 openDriveID=signal_.id_,
                 country=signal_.country,
                 type=signal_.type_,
+                subtype=signal_.subtype,
+                priorities=signal_.priorities,
+                s=signal_.s,
+                t=signal_.t,
+                orientation=signal_.orientation,
+                validity=validity,
+                references=signal_.references,
+                sIsLogical=signal_.sIsLogical,
+                position=Vector(*xy) if xy else None,
             )
             roadSignals.append(signal)
+
+        by_id = {str(sig.openDriveID): sig for sig in roadSignals}
+        plus_contact = self.length if self.successor is not None else None
+        minus_contact = 0.0 if self.predecessor is not None else None
+        for sig in roadSignals:
+            sig.stoppingS = sig.resolveStoppingS(by_id, plus_contact, minus_contact)
 
         # Create road
         assert forwardGroup or backwardGroup
@@ -1233,25 +1290,49 @@ class Road:
 class Signal:
     """Traffic lights, stop signs, etc."""
 
-    def __init__(self, id_, country, type_, subtype, orientation, validity=None):
+    def __init__(
+        self,
+        id_,
+        country,
+        type_,
+        subtype,
+        orientation,
+        s,
+        t,
+        validity=None,
+        priorities=(),
+        references=(),
+        sIsLogical=False,
+    ):
         self.id_ = id_
         self.country = country
         self.type_ = type_
         self.subtype = subtype
         self.orientation = orientation
+        self.s = s
+        self.t = t
         self.validity = validity
+        #: Tuple of `roadDomain.SignalPriorityType` from ``<semantics><priority>``.
+        self.priorities = tuple(priorities)
+        #: Tuple of `roadDomain.SignalLink` from ``<reference>``.
+        self.references = tuple(references)
+        self.sIsLogical = sIsLogical
 
     def is_valid(self):
+        """Whether ``validity`` names a real lane (not CARLA's dummy ``0–0``)."""
         return self.validity is None or self.validity != [0, 0]
 
 
 class SignalReference:
-    def __init__(self, id_, orientation, validity=None):
+    def __init__(self, id_, orientation, s, t, validity=None):
         self.id_ = id_
-        self.validity = validity
         self.orientation = orientation
+        self.s = s
+        self.t = t
+        self.validity = validity
 
     def is_valid(self):
+        """Whether ``validity`` names a real lane (not CARLA's dummy ``0–0``)."""
         return self.validity is None or self.validity != [0, 0]
 
 
@@ -1459,6 +1540,73 @@ class RoadMap:
             return None
         return [int(validity_elem.get("fromLane")), int(validity_elem.get("toLane"))]
 
+    # OpenDRIVE / CARLA country="OpenDRIVE" type codes with a known priority meaning.
+    _LEGACY_TYPE_TO_PRIORITY = {
+        "1000001": roadDomain.SignalPriorityType.TRAFFIC_LIGHT,
+        "206": roadDomain.SignalPriorityType.STOP,
+        "205": roadDomain.SignalPriorityType.YIELD,
+    }
+
+    def __warn_priority_type_disagreement(self, signal):
+        """Warn if a known legacy ``type`` conflicts with ``<priority>`` semantics."""
+        legacy = self._LEGACY_TYPE_TO_PRIORITY.get(signal.type_)
+        if legacy is not None and signal.priorities and legacy not in signal.priorities:
+            listed = ", ".join(p.value for p in signal.priorities)
+            warn(
+                f'signal {signal.id_} has OpenDRIVE type "{signal.type_}" '
+                f"(legacy {legacy.value}) but <priority> lists [{listed}]; "
+                f"using priorities for classification"
+            )
+
+    def __parse_signal_priorities(self, signal_elem):
+        """Parse ``<semantics><priority type="…"/>`` children (OpenDRIVE 1.8+).
+
+        Returns a tuple of `roadDomain.SignalPriorityType`. Unknown literals are
+        mapped to `UNKNOWN` and emit an `OpenDriveWarning`. Other semantic
+        categories (``<speed>``, ``<lane>``, …) are ignored for now.
+        """
+        semantics_elem = signal_elem.find("semantics")
+        if semantics_elem is None:
+            return ()
+        priorities = []
+        for priority_elem in semantics_elem.findall("priority"):
+            type_str = priority_elem.get("type")
+            if type_str is None:
+                warn(
+                    f'signal {signal_elem.get("id")} has <priority> without type; '
+                    "skipping it"
+                )
+                continue
+            priority = roadDomain.SignalPriorityType.fromOpenDrive(type_str)
+            if priority is roadDomain.SignalPriorityType.UNKNOWN:
+                warn(
+                    f'signal {signal_elem.get("id")} has unrecognized '
+                    f'priority type "{type_str}"; storing as UNKNOWN'
+                )
+            priorities.append(priority)
+        return tuple(priorities)
+
+    def __parse_signal_links(self, signal_elem):
+        """Parse ``<reference>`` children (light → stop line, etc.)."""
+        links = []
+        for ref in signal_elem.findall("reference"):
+            element_id = ref.get("elementId")
+            element_type = ref.get("elementType")
+            if not element_id or not element_type:
+                warn(
+                    f'signal {signal_elem.get("id")} has <reference> '
+                    "without elementId or elementType; skipping it"
+                )
+                continue
+            links.append(
+                roadDomain.SignalLink(
+                    elementId=element_id,
+                    elementType=element_type,
+                    type=ref.get("type"),
+                )
+            )
+        return tuple(links)
+
     def __parse_signal(self, signal_elem):
         return Signal(
             signal_elem.get("id"),
@@ -1466,13 +1614,24 @@ class RoadMap:
             signal_elem.get("type"),
             signal_elem.get("subtype"),
             signal_elem.get("orientation"),
+            float(signal_elem.get("s")),
+            float(signal_elem.get("t")),
+            # other required fields not parsed:
+            # dynamic   signal_elem.get("dynamic"),
+            # zOffset   signal_elem.get("zOffset"),
             self.__parse_signal_validity(signal_elem.find("validity")),
+            self.__parse_signal_priorities(signal_elem),
+            self.__parse_signal_links(signal_elem),
+            signal_elem.find("positionRoad") is not None
+            or signal_elem.find("positionInertial") is not None,
         )
 
     def __parse_signal_reference(self, signal_reference_elem):
         return SignalReference(
             signal_reference_elem.get("id"),
             signal_reference_elem.get("orientation"),
+            float(signal_reference_elem.get("s")),
+            float(signal_reference_elem.get("t")),
             self.__parse_signal_validity(signal_reference_elem.find("validity")),
         )
 
@@ -1676,22 +1835,29 @@ class RoadMap:
             if signals is not None:
                 for signal_elem in signals.iter("signal"):
                     signal = self.__parse_signal(signal_elem)
-                    if signal.is_valid():
-                        road.signals.append(signal)
+                    # Do not drop CARLA dummy validity [0, 0]. Those are real
+                    # lights; maneuver matching still ignores a 0-0 range.
+                    self.__warn_priority_type_disagreement(signal)
+                    road.signals.append(signal)
 
                 for signal_ref_elem in signals.iter("signalReference"):
                     signalReference = self.__parse_signal_reference(signal_ref_elem)
-                    if signalReference.is_valid():
-                        referencedSignal = _temp_signals[signalReference.id_]
-                        signal = Signal(
-                            referencedSignal.id_,
-                            referencedSignal.country,
-                            referencedSignal.type_,
-                            referencedSignal.subtype,
-                            signalReference.orientation,
-                            signalReference.validity,
-                        )
-                        road.signals.append(signal)
+                    referencedSignal = _temp_signals[signalReference.id_]
+                    # Semantics come from the canonical <signal>; placement
+                    # (s/t/orientation/validity) is this road's <signalReference>.
+                    signal = Signal(
+                        referencedSignal.id_,
+                        referencedSignal.country,
+                        referencedSignal.type_,
+                        referencedSignal.subtype,
+                        signalReference.orientation,
+                        signalReference.s,
+                        signalReference.t,
+                        signalReference.validity,
+                        referencedSignal.priorities,
+                        referencedSignal.references,
+                    )
+                    road.signals.append(signal)
 
             if len(road.lane_secs) > 1:
                 popLastSectionIfShort(road.length - s)

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -1187,6 +1187,7 @@ class Road:
                 type=signal_.type_,
                 subtype=signal_.subtype,
                 priorities=signal_.priorities,
+                tags=signal_.tags,
                 s=signal_.s,
                 t=signal_.t,
                 orientation=signal_.orientation,
@@ -1285,6 +1286,7 @@ class Signal:
         t,
         validity=None,
         priorities=(),
+        tags=(),
         references=(),
         sIsLogical=False,
     ):
@@ -1298,6 +1300,8 @@ class Signal:
         self.validity = validity
         #: Tuple of `roadDomain.SignalPriorityType` from ``<semantics><priority>``.
         self.priorities = tuple(priorities)
+        #: Exact OpenDRIVE 1.8+ semantic tag strings.
+        self.tags = frozenset(tags)
         #: Tuple of `roadDomain.SignalLink` from ``<reference>``.
         self.references = tuple(references)
         self.sIsLogical = sIsLogical
@@ -1568,6 +1572,17 @@ class RoadMap:
             priorities.append(roadDomain.SignalPriorityType.fromOpenDrive(type_str))
         return tuple(priorities)
 
+    def __parse_signal_tags(self, signal_elem):
+        """Preserve exact OpenDRIVE 1.8+ priority semantics as signal tags."""
+        semantics_elem = signal_elem.find("semantics")
+        if semantics_elem is None:
+            return frozenset()
+        return frozenset(
+            type_str
+            for priority_elem in semantics_elem.findall("priority")
+            if (type_str := priority_elem.get("type")) is not None
+        )
+
     def __parse_signal_links(self, signal_elem):
         """Parse ``<reference>`` children (light → stop line, etc.)."""
         links = []
@@ -1603,6 +1618,7 @@ class RoadMap:
             # zOffset   signal_elem.get("zOffset"),
             self.__parse_signal_validity(signal_elem.find("validity")),
             self.__parse_signal_priorities(signal_elem),
+            self.__parse_signal_tags(signal_elem),
             self.__parse_signal_links(signal_elem),
             signal_elem.find("positionRoad") is not None
             or signal_elem.find("positionInertial") is not None,
@@ -1837,6 +1853,7 @@ class RoadMap:
                         signalReference.t,
                         signalReference.validity,
                         referencedSignal.priorities,
+                        referencedSignal.tags,
                         referencedSignal.references,
                     )
                     road.signals.append(signal)

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -1293,7 +1293,7 @@ class Signal:
         self.orientation = orientation
         self.s = s
         self.t = t
-        #: Tuple of `roadDomain.SignalPriorityType` from ``<semantics><priority>``.
+        #: Tuple of `scenic.domains.driving.roads.SignalPriorityType` from ``<semantics><priority>``.
         self.priorities = tuple(priorities)
         #: Exact OpenDRIVE 1.8+ semantic tag strings.
         self.tags = frozenset(tags)
@@ -1531,7 +1531,7 @@ class RoadMap:
         """Parse ``<semantics><priority type="…"/>`` children (OpenDRIVE 1.8+).
 
         Stop, yield, and traffic-light literals are mapped to broad
-        `roadDomain.SignalPriorityType` categories. Other literals are retained
+        `scenic.domains.driving.roads.SignalPriorityType` categories. Other literals are retained
         verbatim as strings. Other semantic categories (``<speed>``, ``<lane>``,
         …) are ignored for now.
         """

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -1192,19 +1192,16 @@ class Road:
                 t=signal_.t,
                 orientation=signal_.orientation,
                 validity=validity,
-                references=signal_.references,
-                sIsLogical=signal_.sIsLogical,
                 # Placeholder: physical pole coordinates are not needed for halt
                 # decisions, which use stoppingS and stoppingPositionOn instead.
                 position=None,
             )
             roadSignals.append(signal)
 
-        by_id = {str(sig.openDriveID): sig for sig in roadSignals}
         plus_contact = self.length if self.successor is not None else None
         minus_contact = 0.0 if self.predecessor is not None else None
         for sig in roadSignals:
-            sig.stoppingS = sig.resolveStoppingS(by_id, plus_contact, minus_contact)
+            sig.stoppingS = sig.resolveStoppingS(plus_contact, minus_contact)
 
         # Create road
         assert forwardGroup or backwardGroup
@@ -1266,6 +1263,8 @@ class Road:
                 sec.group = backwardGroup
                 sec.road = road
                 del sec._original_lane
+        for signal in roadSignals:
+            signal.road = road
 
         road._propagateSignals()
 
@@ -2104,6 +2103,8 @@ class RoadMap:
             intersections[jid] = intersection
             for maneuver in allManeuvers:
                 object.__setattr__(maneuver, "intersection", intersection)
+            for signal in allSignals:
+                signal.intersection = intersection
 
         # Hook up road-intersection links
         for rid, oldRoad in self.roads.items():
@@ -2122,6 +2123,20 @@ class RoadMap:
                 newRoad.sections[-1]._successor = intersection
                 if newRoad.forwardLanes:
                     newRoad.forwardLanes._successor = intersection
+
+        for intersection in intersections.values():
+            for road in intersection.roads:
+                if road._successor is intersection:
+                    contact_s = road.centerline.length
+                elif road._predecessor is intersection:
+                    contact_s = 0.0
+                else:
+                    continue
+                for signal in road.signals:
+                    if signal.stoppingS is None:
+                        continue
+                    if abs(signal.stoppingS - contact_s) <= 1e-4:
+                        signal.intersection = intersection
 
         # Gather all network elements
         roads = tuple(mainRoads.values())

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -1179,7 +1179,6 @@ class Road:
         # Create signal
         roadSignals = []
         for i, signal_ in enumerate(self.signals):
-            validity = None if signal_.validity is None else tuple(signal_.validity)
             signal = roadDomain.Signal(
                 uid=f"signal{signal_.id_}_{self.id_}_{i}",
                 openDriveID=signal_.id_,
@@ -1191,7 +1190,6 @@ class Road:
                 s=signal_.s,
                 t=signal_.t,
                 orientation=signal_.orientation,
-                validity=validity,
                 # Placeholder: physical pole coordinates are not needed for halt
                 # decisions, which use stoppingS and stoppingPositionOn instead.
                 position=None,
@@ -1283,7 +1281,6 @@ class Signal:
         orientation,
         s,
         t,
-        validity=None,
         priorities=(),
         tags=(),
     ):
@@ -1294,28 +1291,18 @@ class Signal:
         self.orientation = orientation
         self.s = s
         self.t = t
-        self.validity = validity
         #: Tuple of `roadDomain.SignalPriorityType` from ``<semantics><priority>``.
         self.priorities = tuple(priorities)
         #: Exact OpenDRIVE 1.8+ semantic tag strings.
         self.tags = frozenset(tags)
 
-    def is_valid(self):
-        """Whether ``validity`` names a real lane (not CARLA's dummy ``0–0``)."""
-        return self.validity is None or self.validity != [0, 0]
-
 
 class SignalReference:
-    def __init__(self, id_, orientation, s, t, validity=None):
+    def __init__(self, id_, orientation, s, t):
         self.id_ = id_
         self.orientation = orientation
         self.s = s
         self.t = t
-        self.validity = validity
-
-    def is_valid(self):
-        """Whether ``validity`` names a real lane (not CARLA's dummy ``0–0``)."""
-        return self.validity is None or self.validity != [0, 0]
 
 
 class RoadMap:
@@ -1517,11 +1504,6 @@ class RoadMap:
                         RoadLink(road_id, c.connecting_id, contact, c.connecting_contact)
                     )
 
-    def __parse_signal_validity(self, validity_elem):
-        if validity_elem is None:
-            return None
-        return [int(validity_elem.get("fromLane")), int(validity_elem.get("toLane"))]
-
     # OpenDRIVE / CARLA country="OpenDRIVE" type codes with a known priority meaning.
     _LEGACY_TYPE_TO_PRIORITY = {
         "1000001": roadDomain.SignalPriorityType.TRAFFIC_LIGHT,
@@ -1589,7 +1571,6 @@ class RoadMap:
             # other required fields not parsed:
             # dynamic   signal_elem.get("dynamic"),
             # zOffset   signal_elem.get("zOffset"),
-            self.__parse_signal_validity(signal_elem.find("validity")),
             self.__parse_signal_priorities(signal_elem),
             self.__parse_signal_tags(signal_elem),
         )
@@ -1600,7 +1581,6 @@ class RoadMap:
             signal_reference_elem.get("orientation"),
             float(signal_reference_elem.get("s")),
             float(signal_reference_elem.get("t")),
-            self.__parse_signal_validity(signal_reference_elem.find("validity")),
         )
 
     def parse(self, path):
@@ -1803,8 +1783,6 @@ class RoadMap:
             if signals is not None:
                 for signal_elem in signals.iter("signal"):
                     signal = self.__parse_signal(signal_elem)
-                    # Do not drop CARLA dummy validity [0, 0]. Those are real
-                    # lights; maneuver matching still ignores a 0-0 range.
                     self.__warn_priority_type_disagreement(signal)
                     road.signals.append(signal)
 
@@ -1812,7 +1790,7 @@ class RoadMap:
                     signalReference = self.__parse_signal_reference(signal_ref_elem)
                     referencedSignal = _temp_signals[signalReference.id_]
                     # Semantics come from the canonical <signal>; placement
-                    # (s/t/orientation/validity) is this road's <signalReference>.
+                    # (s/t/orientation) is this road's <signalReference>.
                     signal = Signal(
                         referencedSignal.id_,
                         referencedSignal.country,
@@ -1821,7 +1799,6 @@ class RoadMap:
                         signalReference.orientation,
                         signalReference.s,
                         signalReference.t,
-                        signalReference.validity,
                         referencedSignal.priorities,
                         referencedSignal.tags,
                     )

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -1211,7 +1211,9 @@ class Road:
             leftEdge = backwardGroup.rightEdge
         else:
             leftEdge = forwardGroup.leftEdge
-        centerline = PolylineRegion(cleanChain(tuple(pt[:2] for pt in self.ref_line_points)))
+        centerline = PolylineRegion(
+            cleanChain(tuple(pt[:2] for pt in self.ref_line_points))
+        )
         road = roadDomain.Road(
             name=self.name,
             uid=f"road{self.id_}",  # need prefix to prevent collisions with intersections
@@ -1826,6 +1828,34 @@ class RoadMap:
                     continue  # link to intersection
             new_links.append(link)
         self.road_links = new_links
+        self._attachConnectorSignalsToIncomingRoads()
+
+    def _attachConnectorSignalsToIncomingRoads(self):
+        """Put junction-road signals on the incoming approach before Scenic conversion."""
+        seen = set()
+        for jid, junction in self.junctions.items():
+            for connection in junction.connections:
+                connecting = self.roads.get(connection.connecting_id)
+                incoming = self.roads.get(connection.incoming_id)
+                if connecting is None or incoming is None:
+                    continue
+                if connecting.id_ in seen:
+                    continue
+                seen.add(connecting.id_)
+                if incoming.successor == jid:
+                    contact_s = incoming.length
+                elif incoming.predecessor == jid:
+                    contact_s = 0.0
+                else:
+                    continue
+                have = {signal.id_ for signal in incoming.signals}
+                for signal in connecting.signals:
+                    if signal.id_ in have:
+                        continue
+                    signal.s = contact_s
+                    incoming.signals.append(signal)
+                    have.add(signal.id_)
+                connecting.signals = []
 
     def toScenicNetwork(self):
         assert self.intersection_region is not None
@@ -1909,7 +1939,6 @@ class RoadMap:
             # Gather all lanes involved in the junction's connections
             allIncomingLanes, allOutgoingLanes = [], []
             allRoads, seenRoads = [], set()
-            allSignals, seenSignals = [], set()
             maneuversForLane = defaultdict(list)
             for connection in junction.connections:
                 incomingID = connection.incoming_id
@@ -1921,11 +1950,6 @@ class RoadMap:
                 connectingRoad = connectingRoads.get(connectingID)
                 if not connectingRoad:
                     continue  # connecting road has no drivable lanes; skip it
-
-                for signal in connectingRoad.signals:
-                    if signal.openDriveID not in seenSignals:
-                        allSignals.append(signal)
-                        seenSignals.add(signal.openDriveID)
 
                 # Find possible incoming lanes for this connection
                 if incomingID not in seenRoads:
@@ -2043,15 +2067,13 @@ class RoadMap:
                 incomingLanes=cyclicOrder(allIncomingLanes, contactStart=False),
                 outgoingLanes=cyclicOrder(allOutgoingLanes, contactStart=True),
                 maneuvers=tuple(allManeuvers),
-                signals=tuple(allSignals),
+                signals=(),
                 crossings=(),  # TODO add these
             )
             register(intersection)
             intersections[jid] = intersection
             for maneuver in allManeuvers:
                 object.__setattr__(maneuver, "intersection", intersection)
-            for signal in allSignals:
-                signal.intersection = intersection
 
         # Hook up road-intersection links
         for rid, oldRoad in self.roads.items():
@@ -2072,6 +2094,8 @@ class RoadMap:
                     newRoad.forwardLanes._successor = intersection
 
         for intersection in intersections.values():
+            placed = []
+            seen = set()
             for road in intersection.roads:
                 if road._successor is intersection:
                     contact_s = road.centerline.length
@@ -2082,8 +2106,14 @@ class RoadMap:
                 for signal in road.signals:
                     if signal.stoppingS is None:
                         continue
-                    if abs(signal.stoppingS - contact_s) <= 1e-4:
-                        signal.intersection = intersection
+                    if abs(signal.stoppingS - contact_s) > 1e-4:
+                        continue
+                    signal.intersection = intersection
+                    if id(signal) in seen:
+                        continue
+                    placed.append(signal)
+                    seen.add(id(signal))
+            intersection.signals = tuple(placed)
 
         # Gather all network elements
         roads = tuple(mainRoads.values())

--- a/src/scenic/formats/opendrive/xodr_parser.py
+++ b/src/scenic/formats/opendrive/xodr_parser.py
@@ -1286,8 +1286,6 @@ class Signal:
         validity=None,
         priorities=(),
         tags=(),
-        references=(),
-        sIsLogical=False,
     ):
         self.id_ = id_
         self.country = country
@@ -1301,9 +1299,6 @@ class Signal:
         self.priorities = tuple(priorities)
         #: Exact OpenDRIVE 1.8+ semantic tag strings.
         self.tags = frozenset(tags)
-        #: Tuple of `roadDomain.SignalLink` from ``<reference>``.
-        self.references = tuple(references)
-        self.sIsLogical = sIsLogical
 
     def is_valid(self):
         """Whether ``validity`` names a real lane (not CARLA's dummy ``0–0``)."""
@@ -1582,27 +1577,6 @@ class RoadMap:
             if (type_str := priority_elem.get("type")) is not None
         )
 
-    def __parse_signal_links(self, signal_elem):
-        """Parse ``<reference>`` children (light → stop line, etc.)."""
-        links = []
-        for ref in signal_elem.findall("reference"):
-            element_id = ref.get("elementId")
-            element_type = ref.get("elementType")
-            if not element_id or not element_type:
-                warn(
-                    f'signal {signal_elem.get("id")} has <reference> '
-                    "without elementId or elementType; skipping it"
-                )
-                continue
-            links.append(
-                roadDomain.SignalLink(
-                    elementId=element_id,
-                    elementType=element_type,
-                    type=ref.get("type"),
-                )
-            )
-        return tuple(links)
-
     def __parse_signal(self, signal_elem):
         return Signal(
             signal_elem.get("id"),
@@ -1618,9 +1592,6 @@ class RoadMap:
             self.__parse_signal_validity(signal_elem.find("validity")),
             self.__parse_signal_priorities(signal_elem),
             self.__parse_signal_tags(signal_elem),
-            self.__parse_signal_links(signal_elem),
-            signal_elem.find("positionRoad") is not None
-            or signal_elem.find("positionInertial") is not None,
         )
 
     def __parse_signal_reference(self, signal_reference_elem):
@@ -1853,7 +1824,6 @@ class RoadMap:
                         signalReference.validity,
                         referencedSignal.priorities,
                         referencedSignal.tags,
-                        referencedSignal.references,
                     )
                     road.signals.append(signal)
 

--- a/tests/formats/opendrive/test_signal_halt_encodings.py
+++ b/tests/formats/opendrive/test_signal_halt_encodings.py
@@ -1,0 +1,412 @@
+"""Halt-point encodings: deprecated logical-s, signalReference, and CARLA dummy validity.
+
+Junction-contact traffic lights must stop only the arriving direction. The lane
+you turn into at the far side of a green light must not inherit a halt at s=0.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scenic.core.vectors import Vector
+from scenic.domains.driving.roads import Network
+
+# Shared two-way section: +1 travels −s, −1 travels +s.
+_TWOWAY_LANES = """\
+      <laneOffset s="0" a="0" b="0" c="0" d="0"/>
+      <laneSection s="0">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+"""
+
+# Pre-1.8: @s is the effect station; <positionRoad>/<positionInertial> is the pole.
+MAP_DEPRECATED_LOGICAL = f"""<?xml version="1.0" encoding="UTF-8"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="4" name="deprecated_logical_s" version="1.0"/>
+  <road name="TwoWay" length="40.0" id="1" junction="-1">
+    <planView>
+      <geometry s="0" x="0.0" y="0.0" hdg="0.0" length="40.0"><line/></geometry>
+    </planView>
+    <lanes>
+{_TWOWAY_LANES}
+    </lanes>
+    <signals>
+      <signal s="12.0" t="-1.75" id="10" name="legacy_stop" dynamic="no"
+              orientation="-" zOffset="2" type="206" country="OpenDRIVE"
+              subtype="-1" value="-1">
+        <positionRoad roadId="1" s="16.0" t="-4.0" zOffset="2" hOffset="0"/>
+      </signal>
+      <signal s="28.0" t="-1.75" id="11" name="legacy_yield" dynamic="no"
+              orientation="+" zOffset="2" type="205" country="OpenDRIVE"
+              subtype="-1" value="-1">
+        <positionInertial x="30.0" y="-4.0" z="2" hdg="0" pitch="0" roll="0"/>
+      </signal>
+      <signal s="20.0" t="0.0" id="12" name="both_ways_line" dynamic="no"
+              orientation="none" zOffset="0" type="-1" country="OpenDRIVE"
+              subtype="-1" value="-1">
+        <semantics><priority type="stopLine"/></semantics>
+      </signal>
+    </signals>
+  </road>
+</OpenDRIVE>
+"""
+
+# Canonical light on the west approach; same id re-applied on the east road
+# (the road you turn into) via <signalReference>.
+MAP_SIGNAL_REFERENCE = f"""<?xml version="1.0" encoding="UTF-8"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6" name="signal_reference_exit" version="1.0"/>
+  <road name="West Approach" length="20.0" id="1" junction="-1">
+    <link><successor elementType="junction" elementId="100"/></link>
+    <planView>
+      <geometry s="0" x="0.0" y="0.0" hdg="0.0" length="20.0"><line/></geometry>
+    </planView>
+    <lanes>
+{_TWOWAY_LANES}
+    </lanes>
+    <signals>
+      <signal s="18.0" t="-4.0" id="201" name="canonical_light" dynamic="yes"
+              orientation="+" zOffset="5" type="1000001" country="OpenDRIVE"
+              subtype="-1" value="-1"/>
+    </signals>
+  </road>
+  <road name="East Exit" length="20.0" id="2" junction="-1">
+    <link><predecessor elementType="junction" elementId="100"/></link>
+    <planView>
+      <geometry s="0" x="32.0" y="0.0" hdg="0.0" length="20.0"><line/></geometry>
+    </planView>
+    <lanes>
+{_TWOWAY_LANES}
+    </lanes>
+    <signals>
+      <signalReference s="1.5" t="4.0" id="201" orientation="-"/>
+    </signals>
+  </road>
+  <road name="Connector" length="12.0" id="10" junction="100">
+    <link>
+      <predecessor elementType="road" elementId="1" contactPoint="end"/>
+      <successor elementType="road" elementId="2" contactPoint="start"/>
+    </link>
+    <planView>
+      <geometry s="0" x="20.0" y="0.0" hdg="0.0" length="12.0"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneOffset s="0" a="0" b="0" c="0" d="0"/>
+      <laneSection s="0">
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/><successor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+  <junction name="J" id="100">
+    <connection id="0" incomingRoad="1" connectingRoad="10" contactPoint="start">
+      <laneLink from="-1" to="-1"/>
+    </connection>
+  </junction>
+</OpenDRIVE>
+"""
+
+# Same geometry as MAP_SIGNAL_REFERENCE, but CARLA-undefined: dummy 0–0 validity
+# and lamp-facing orientation (often the opposite of the arriving lane).
+MAP_CARLA_TWOWAY = f"""<?xml version="1.0" encoding="UTF-8"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="4" name="carla_twoway_dummy" version="1.0"/>
+  <road name="West Approach" length="20.0" id="1" junction="-1">
+    <link><successor elementType="junction" elementId="100"/></link>
+    <planView>
+      <geometry s="0" x="0.0" y="0.0" hdg="0.0" length="20.0"><line/></geometry>
+    </planView>
+    <lanes>
+{_TWOWAY_LANES}
+    </lanes>
+    <signals>
+      <signal s="18.5" t="-4.5" id="362" name="Signal_3Light_Post01" dynamic="yes"
+              orientation="-" zOffset="0" type="1000001" country="OpenDRIVE"
+              subtype="-1" value="-1">
+        <validity fromLane="0" toLane="0"/>
+      </signal>
+    </signals>
+  </road>
+  <road name="East Exit" length="20.0" id="2" junction="-1">
+    <link><predecessor elementType="junction" elementId="100"/></link>
+    <planView>
+      <geometry s="0" x="32.0" y="0.0" hdg="0.0" length="20.0"><line/></geometry>
+    </planView>
+    <lanes>
+{_TWOWAY_LANES}
+    </lanes>
+    <signals>
+      <signal s="1.5" t="4.5" id="360" name="Signal_3Light_Post01" dynamic="yes"
+              orientation="+" zOffset="0" type="1000001" country="OpenDRIVE"
+              subtype="-1" value="-1">
+        <validity fromLane="0" toLane="0"/>
+      </signal>
+    </signals>
+  </road>
+  <road name="Connector" length="12.0" id="10" junction="100">
+    <link>
+      <predecessor elementType="road" elementId="1" contactPoint="end"/>
+      <successor elementType="road" elementId="2" contactPoint="start"/>
+    </link>
+    <planView>
+      <geometry s="0" x="20.0" y="0.0" hdg="0.0" length="12.0"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneOffset s="0" a="0" b="0" c="0" d="0"/>
+      <laneSection s="0">
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/><successor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+  <junction name="J" id="100">
+    <connection id="0" incomingRoad="1" connectingRoad="10" contactPoint="start">
+      <laneLink from="-1" to="-1"/>
+    </connection>
+  </junction>
+</OpenDRIVE>
+"""
+
+# CARLA-style dummy validity on a <signalReference> (Town10HD hybrid).
+MAP_CARLA_SIGNAL_REFERENCE = MAP_SIGNAL_REFERENCE.replace(
+    '<signalReference s="1.5" t="4.0" id="201" orientation="-"/>',
+    '<signalReference s="1.5" t="4.0" id="201" orientation="+">\n'
+    '        <validity fromLane="0" toLane="0"/>\n'
+    "      </signalReference>",
+)
+
+
+def load_network(tmp_path: Path, xml: str) -> Network:
+    path = tmp_path / "map.xodr"
+    path.write_text(xml)
+    return Network.fromFile(path, useCache=False)
+
+
+def od_id(lane) -> int:
+    ids = {sec.openDriveID for sec in lane.sections}
+    assert len(ids) == 1, lane
+    return next(iter(ids))
+
+
+def lanes_by_id(road):
+    return {od_id(lane): lane for lane in road.lanes}
+
+
+def road_by_id(network, road_id):
+    return next(road for road in network.roads if road.id == road_id)
+
+
+def signal_on(road, open_drive_id):
+    matches = [sig for sig in road.signals if str(sig.openDriveID) == str(open_drive_id)]
+    assert len(matches) == 1, (road.uid, open_drive_id, matches)
+    return matches[0]
+
+
+def _xy(pt, x, y, tol=0.15):
+    assert pt is not None
+    assert abs(pt.x - x) < tol, (pt.x, x)
+    assert abs(pt.y - y) < tol, (pt.y, y)
+
+
+# --- deprecated pre-1.8 logical @s ---
+
+
+def test_deprecated_position_road_halts_at_logical_s_not_pole(tmp_path):
+    network = load_network(tmp_path, MAP_DEPRECATED_LOGICAL)
+    road = road_by_id(network, 1)
+    lanes = lanes_by_id(road)
+    stop = signal_on(road, 10)
+    assert stop.sIsLogical
+    assert stop.s == 12.0
+    assert stop.stoppingS == 12.0
+    assert stop.stoppingPointOn(lanes[-1]) is None
+    _xy(stop.stoppingPointOn(lanes[1]), 12.0, 1.75)
+
+
+def test_deprecated_position_inertial_halts_at_logical_s(tmp_path):
+    network = load_network(tmp_path, MAP_DEPRECATED_LOGICAL)
+    road = road_by_id(network, 1)
+    lanes = lanes_by_id(road)
+    yield_sig = signal_on(road, 11)
+    assert yield_sig.sIsLogical
+    assert yield_sig.stoppingS == 28.0
+    _xy(yield_sig.stoppingPointOn(lanes[-1]), 28.0, -1.75)
+    assert yield_sig.stoppingPointOn(lanes[1]) is None
+
+
+def test_deprecated_midroad_stopline_still_both_directions(tmp_path):
+    """A painted line at mid-s is not a junction entry; both directions halt."""
+    network = load_network(tmp_path, MAP_DEPRECATED_LOGICAL)
+    road = road_by_id(network, 1)
+    lanes = lanes_by_id(road)
+    line = signal_on(road, 12)
+    assert not line.sIsLogical
+    assert line.stoppingS == 20.0
+    _xy(line.stoppingPointOn(lanes[-1]), 20.0, -1.75)
+    _xy(line.stoppingPointOn(lanes[1]), 20.0, 1.75)
+
+
+def test_deprecated_halt_point_ahead_skips_opposite_direction(tmp_path):
+    network = load_network(tmp_path, MAP_DEPRECATED_LOGICAL)
+    road = road_by_id(network, 1)
+    lanes = lanes_by_id(road)
+    # +s traffic: stop line at 20, then yield at 28. Opposite stop at 12 is behind.
+    first = lanes[-1].haltPointAhead(Vector(1, -1.75))
+    _xy(first, 20.0, -1.75)
+    second = lanes[-1].haltPointAhead(Vector(21, -1.75))
+    _xy(second, 28.0, -1.75)
+    assert lanes[-1].haltPointAhead(Vector(29, -1.75)) is None
+
+
+# --- <signalReference> (same signal, other road) ---
+
+
+def test_signal_reference_keeps_this_roads_placement(tmp_path):
+    network = load_network(tmp_path, MAP_SIGNAL_REFERENCE)
+    west = road_by_id(network, 1)
+    east = road_by_id(network, 2)
+    canonical = signal_on(west, 201)
+    clone = signal_on(east, 201)
+    assert canonical.type == clone.type == "1000001"
+    assert canonical.s == 18.0
+    assert clone.s == 1.5
+    assert clone.orientation == "-"
+    assert canonical.uid != clone.uid
+
+
+def test_signal_reference_on_exit_does_not_stop_outgoing(tmp_path):
+    """Turning onto the east road must not halt at that road's s≈0 clone."""
+    network = load_network(tmp_path, MAP_SIGNAL_REFERENCE)
+    west = road_by_id(network, 1)
+    east = road_by_id(network, 2)
+    west_lanes = lanes_by_id(west)
+    east_lanes = lanes_by_id(east)
+    canonical = signal_on(west, 201)
+    clone = signal_on(east, 201)
+
+    _xy(canonical.stoppingPointOn(west_lanes[-1]), 20.0, -1.75)
+    assert canonical.stoppingPointOn(west_lanes[1]) is None
+
+    # Backward on the east road is still arriving at the junction.
+    _xy(clone.stoppingPointOn(east_lanes[1]), 32.0, 1.75)
+    # Forward on the east road just left the junction.
+    assert clone.stoppingPointOn(east_lanes[-1]) is None
+    assert east_lanes[-1].haltPointAhead(Vector(33.0, -1.75)) is None
+
+
+def test_signal_reference_connector_has_no_invented_halt(tmp_path):
+    network = load_network(tmp_path, MAP_SIGNAL_REFERENCE)
+    connector = next(road for road in network.connectingRoads if road.id == 10)
+    for sig in connector.signals:
+        for lane in connector.lanes:
+            assert sig.stoppingPointOn(lane) is None
+
+
+def test_carla_dummy_signal_reference_on_exit(tmp_path):
+    """Town10HD-style: dummy validity on the reference still must not stop the exit."""
+    network = load_network(tmp_path, MAP_CARLA_SIGNAL_REFERENCE)
+    east = road_by_id(network, 2)
+    lanes = lanes_by_id(east)
+    clone = signal_on(east, 201)
+    assert clone.validity == (0, 0)
+    assert clone.orientation == "+"  # lamp facing; would wrongly pick the exit
+    _xy(clone.stoppingPointOn(lanes[1]), 32.0, 1.75)
+    assert clone.stoppingPointOn(lanes[-1]) is None
+    assert lanes[-1].haltPointAhead(Vector(33.0, -1.75)) is None
+
+
+# --- CARLA / RoadRunner undefined (dummy 0–0, pole only) ---
+
+
+def test_carla_twoway_arriving_side_halts_leaving_side_does_not(tmp_path):
+    network = load_network(tmp_path, MAP_CARLA_TWOWAY)
+    west = road_by_id(network, 1)
+    east = road_by_id(network, 2)
+    west_lanes = lanes_by_id(west)
+    east_lanes = lanes_by_id(east)
+    west_light = signal_on(west, 362)
+    east_light = signal_on(east, 360)
+
+    assert west_light.validity == (0, 0)
+    assert east_light.validity == (0, 0)
+    assert west_light.stoppingS == 20.0
+    assert east_light.stoppingS == 0.0
+
+    # West +s is arriving at the junction.
+    _xy(west_light.stoppingPointOn(west_lanes[-1]), 20.0, -1.75)
+    assert west_light.stoppingPointOn(west_lanes[1]) is None
+
+    # East +s is the road you turn into; −s is the opposite approach.
+    assert east_light.stoppingPointOn(east_lanes[-1]) is None
+    _xy(east_light.stoppingPointOn(east_lanes[1]), 32.0, 1.75)
+
+
+def test_carla_green_light_then_no_stop_on_exit_lane(tmp_path):
+    """After the west stop, haltPointAhead on the east exit lane is empty."""
+    network = load_network(tmp_path, MAP_CARLA_TWOWAY)
+    west = road_by_id(network, 1)
+    east = road_by_id(network, 2)
+    west_fwd = lanes_by_id(west)[-1]
+    east_fwd = lanes_by_id(east)[-1]
+    _xy(west_fwd.haltPointAhead(Vector(1.0, -1.75)), 20.0, -1.75)
+    assert east_fwd.haltPointAhead(Vector(33.0, -1.75)) is None
+    # Exactly at the east road start (s=0) must not count as a stop either.
+    assert east_fwd.haltPointAhead(Vector(32.0, -1.75)) is None
+
+
+def test_carla_connector_lights_do_not_invent_a_stop(tmp_path):
+    network = load_network(tmp_path, MAP_CARLA_TWOWAY)
+    for road in network.connectingRoads:
+        for sig in road.signals:
+            assert sig.stoppingS is None
+            for lane in road.lanes:
+                assert sig.stoppingPointOn(lane) is None
+
+
+@pytest.mark.slow
+def test_town01_exit_lane_does_not_halt_at_entry(getAssetPath):
+    """Town01 intersection26: road 1 +s leaves the junction and must not stop there."""
+    from scenic.core.geometry import TriangulationError
+
+    path = Path(getAssetPath("maps/CARLA/Town01.xodr"))
+    if not path.exists():
+        pytest.skip("Town01.xodr not shipped")
+    try:
+        network = Network.fromOpenDrive(path, ref_points=40, tolerance=0.05)
+    except TriangulationError:
+        pytest.skip("need better triangulation library")
+
+    road1 = road_by_id(network, 1)
+    lanes = lanes_by_id(road1)
+    # OpenDRIVE +1 is −s (arriving at junction 26); −1 is +s (leaving it).
+    arriving = lanes[1]
+    leaving = lanes[-1]
+    entry_light = next(
+        sig
+        for sig in road1.signals
+        if sig.stoppingS is not None and abs(sig.stoppingS) <= 1e-4
+    )
+    assert entry_light.stoppingPointOn(arriving) is not None
+    assert entry_light.stoppingPointOn(leaving) is None
+    start = leaving.centerline.pointAlongBy(1.0)
+    assert leaving.haltPointAhead(start, lookahead=15.0) is None

--- a/tests/formats/opendrive/test_signal_halt_encodings.py
+++ b/tests/formats/opendrive/test_signal_halt_encodings.py
@@ -315,6 +315,19 @@ def test_parser_keeps_categories_and_uncategorized_details(tmp_path):
         "keepClearLine",
         "vendorSpecificPriority",
     )
+    assert signal.tags == frozenset(
+        {"stopLine", "keepClearLine", "vendorSpecificPriority"}
+    )
+
+
+def test_country_and_subtype_warn_in_favor_of_semantic_tags(tmp_path):
+    road = road_by_id(load_network(tmp_path, MAP_DEPRECATED_LOGICAL), 1)
+    signal = signal_on(road, 12)
+    assert signal.tags == frozenset({"stopLine"})
+    with pytest.warns(DeprecationWarning, match=r"Signal\.country.*Signal\.tags"):
+        assert signal.country == "OpenDRIVE"
+    with pytest.warns(DeprecationWarning, match=r"Signal\.subtype.*Signal\.tags"):
+        assert signal.subtype == "-1"
 
 
 # --- deprecated pre-1.8 logical @s ---

--- a/tests/formats/opendrive/test_signal_halt_encodings.py
+++ b/tests/formats/opendrive/test_signal_halt_encodings.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from scenic.core.vectors import Vector
-from scenic.domains.driving.roads import Network
+from scenic.domains.driving.roads import Network, SignalPriorityType
 
 # Shared two-way section: +1 travels −s, −1 travels +s.
 _TWOWAY_LANES = """\
@@ -23,6 +23,40 @@ _TWOWAY_LANES = """\
         <center><lane id="0" type="none" level="false"/></center>
         <right>
           <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+"""
+
+_TWOWAY_TWO_SECTIONS = """\
+      <laneOffset s="0" a="0" b="0" c="0" d="0"/>
+      <laneSection s="0">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <link><successor id="1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><successor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="20">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <link><predecessor id="1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/></link>
             <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
           </lane>
         </right>
@@ -60,6 +94,10 @@ MAP_DEPRECATED_LOGICAL = f"""<?xml version="1.0" encoding="UTF-8"?>
   </road>
 </OpenDRIVE>
 """
+
+MAP_DEPRECATED_TWO_SECTIONS = MAP_DEPRECATED_LOGICAL.replace(
+    _TWOWAY_LANES, _TWOWAY_TWO_SECTIONS
+)
 
 # Canonical light on the west approach; same id re-applied on the east road
 # (the road you turn into) via <signalReference>.
@@ -222,10 +260,61 @@ def signal_on(road, open_drive_id):
     return matches[0]
 
 
-def _xy(pt, x, y, tol=0.15):
-    assert pt is not None
-    assert abs(pt.x - x) < tol, (pt.x, x)
-    assert abs(pt.y - y) < tol, (pt.y, y)
+def _st(position, s, t, tol=0.15):
+    assert position is not None
+    actual_s, actual_t = position
+    assert abs(actual_s - s) < tol, (actual_s, s)
+    assert abs(actual_t - t) < tol, (actual_t, t)
+
+
+@pytest.mark.parametrize(
+    "literal, category",
+    (
+        ("4way", SignalPriorityType.STOP),
+        ("stop", SignalPriorityType.STOP),
+        ("stopLine", SignalPriorityType.STOP),
+        ("yield", SignalPriorityType.YIELD),
+        ("trafficLight", SignalPriorityType.TRAFFIC_LIGHT),
+        ("turnOnRedAllowed", SignalPriorityType.TRAFFIC_LIGHT),
+    ),
+)
+def test_signal_priority_categories(literal, category):
+    assert SignalPriorityType.fromOpenDrive(literal) is category
+
+
+@pytest.mark.parametrize(
+    "detail",
+    (
+        "keepClearLine",
+        "noParkingLine",
+        "noTurnOnRed",
+        "priorityRoad",
+        "priorityRoadEnd",
+        "priorityToTheRightRule",
+        "waitingLine",
+        "vendorSpecificPriority",
+    ),
+)
+def test_uncategorized_signal_priorities_keep_detail(detail):
+    assert SignalPriorityType.fromOpenDrive(detail) == detail
+
+
+def test_parser_keeps_categories_and_uncategorized_details(tmp_path):
+    xml = MAP_DEPRECATED_LOGICAL.replace(
+        '<semantics><priority type="stopLine"/></semantics>',
+        """<semantics>
+          <priority type="stopLine"/>
+          <priority type="keepClearLine"/>
+          <priority type="vendorSpecificPriority"/>
+        </semantics>""",
+    )
+    road = road_by_id(load_network(tmp_path, xml), 1)
+    signal = signal_on(road, 12)
+    assert signal.priorities == (
+        SignalPriorityType.STOP,
+        "keepClearLine",
+        "vendorSpecificPriority",
+    )
 
 
 # --- deprecated pre-1.8 logical @s ---
@@ -239,8 +328,8 @@ def test_deprecated_position_road_halts_at_logical_s_not_pole(tmp_path):
     assert stop.sIsLogical
     assert stop.s == 12.0
     assert stop.stoppingS == 12.0
-    assert stop.stoppingPointOn(lanes[-1]) is None
-    _xy(stop.stoppingPointOn(lanes[1]), 12.0, 1.75)
+    assert stop.stoppingPositionOn(lanes[-1]) is None
+    _st(stop.stoppingPositionOn(lanes[1]), 12.0, 1.75)
 
 
 def test_deprecated_position_inertial_halts_at_logical_s(tmp_path):
@@ -250,8 +339,8 @@ def test_deprecated_position_inertial_halts_at_logical_s(tmp_path):
     yield_sig = signal_on(road, 11)
     assert yield_sig.sIsLogical
     assert yield_sig.stoppingS == 28.0
-    _xy(yield_sig.stoppingPointOn(lanes[-1]), 28.0, -1.75)
-    assert yield_sig.stoppingPointOn(lanes[1]) is None
+    _st(yield_sig.stoppingPositionOn(lanes[-1]), 28.0, -1.75)
+    assert yield_sig.stoppingPositionOn(lanes[1]) is None
 
 
 def test_deprecated_midroad_stopline_still_both_directions(tmp_path):
@@ -262,20 +351,68 @@ def test_deprecated_midroad_stopline_still_both_directions(tmp_path):
     line = signal_on(road, 12)
     assert not line.sIsLogical
     assert line.stoppingS == 20.0
-    _xy(line.stoppingPointOn(lanes[-1]), 20.0, -1.75)
-    _xy(line.stoppingPointOn(lanes[1]), 20.0, 1.75)
+    _st(line.stoppingPositionOn(lanes[-1]), 20.0, -1.75)
+    _st(line.stoppingPositionOn(lanes[1]), 20.0, 1.75)
 
 
-def test_deprecated_halt_point_ahead_skips_opposite_direction(tmp_path):
+def test_deprecated_halt_s_value_ahead_skips_opposite_direction(tmp_path):
     network = load_network(tmp_path, MAP_DEPRECATED_LOGICAL)
     road = road_by_id(network, 1)
     lanes = lanes_by_id(road)
     # +s traffic: stop line at 20, then yield at 28. Opposite stop at 12 is behind.
-    first = lanes[-1].haltPointAhead(Vector(1, -1.75))
-    _xy(first, 20.0, -1.75)
-    second = lanes[-1].haltPointAhead(Vector(21, -1.75))
-    _xy(second, 28.0, -1.75)
-    assert lanes[-1].haltPointAhead(Vector(29, -1.75)) is None
+    _st(lanes[-1].haltPositionAhead(Vector(1, -1.75)), 20.0, -1.75)
+    _st(lanes[-1].haltPositionAhead(Vector(21, -1.75)), 28.0, -1.75)
+    assert lanes[-1].haltPositionAhead(Vector(29, -1.75)) is None
+
+
+def test_signal_lookups_propagate_in_each_elements_travel_order(tmp_path):
+    network = load_network(tmp_path, MAP_DEPRECATED_LOGICAL)
+    road = road_by_id(network, 1)
+    lanes = lanes_by_id(road)
+
+    road_entries, road_s_values = road.signalLookup()
+    assert [entry[1].openDriveID for entry in road_entries] == ["10", "12", "11"]
+    assert road_s_values == [12.0, 20.0, 28.0]
+
+    forward_entries, forward_s_values = lanes[-1].signalLookup()
+    assert [entry[1].openDriveID for entry in forward_entries] == ["12", "11"]
+    assert forward_s_values == [20.0, 28.0]
+    assert [entry[1].openDriveID for entry in lanes[-1].signalsAhead(20.1)] == ["11"]
+
+    backward_entries, backward_s_values = lanes[1].signalLookup()
+    assert [entry[1].openDriveID for entry in backward_entries] == ["12", "10"]
+    assert backward_s_values == [20.0, 28.0]
+    assert [entry[2] for entry in backward_entries] == [20.0, 12.0]
+    assert [entry[1].openDriveID for entry in lanes[1].signalsAhead(20.1)] == ["10"]
+
+    for lane in lanes.values():
+        assert lane.sections[0].signalLookup() == lane.signalLookup()
+    section_entries, section_s_values = road.sections[0].signalLookup()
+    assert [entry[1].openDriveID for entry in section_entries] == ["10", "12", "11"]
+    assert section_s_values == [12.0, 20.0, 28.0]
+
+
+def test_signal_propagation_filters_sections_and_resolves_boundary(tmp_path):
+    network = load_network(tmp_path, MAP_DEPRECATED_TWO_SECTIONS)
+    road = road_by_id(network, 1)
+    lanes = lanes_by_id(road)
+
+    forward_sections = lanes[-1].sections
+    assert [
+        [entry[1].openDriveID for entry in section.signalLookup()[0]]
+        for section in forward_sections
+    ] == [["12"], ["11"]]
+
+    backward_sections = lanes[1].sections
+    assert [
+        [entry[1].openDriveID for entry in section.signalLookup()[0]]
+        for section in backward_sections
+    ] == [["12"], ["10"]]
+
+    assert [
+        [entry[1].openDriveID for entry in section.signalLookup()[0]]
+        for section in road.sections
+    ] == [["10", "12"], ["12", "11"]]
 
 
 # --- <signalReference> (same signal, other road) ---
@@ -304,14 +441,14 @@ def test_signal_reference_on_exit_does_not_stop_outgoing(tmp_path):
     canonical = signal_on(west, 201)
     clone = signal_on(east, 201)
 
-    _xy(canonical.stoppingPointOn(west_lanes[-1]), 20.0, -1.75)
-    assert canonical.stoppingPointOn(west_lanes[1]) is None
+    _st(canonical.stoppingPositionOn(west_lanes[-1]), 20.0, -1.75)
+    assert canonical.stoppingPositionOn(west_lanes[1]) is None
 
     # Backward on the east road is still arriving at the junction.
-    _xy(clone.stoppingPointOn(east_lanes[1]), 32.0, 1.75)
+    _st(clone.stoppingPositionOn(east_lanes[1]), 0.0, 1.75)
     # Forward on the east road just left the junction.
-    assert clone.stoppingPointOn(east_lanes[-1]) is None
-    assert east_lanes[-1].haltPointAhead(Vector(33.0, -1.75)) is None
+    assert clone.stoppingPositionOn(east_lanes[-1]) is None
+    assert east_lanes[-1].haltPositionAhead(Vector(33.0, -1.75)) is None
 
 
 def test_signal_reference_connector_has_no_invented_halt(tmp_path):
@@ -319,7 +456,7 @@ def test_signal_reference_connector_has_no_invented_halt(tmp_path):
     connector = next(road for road in network.connectingRoads if road.id == 10)
     for sig in connector.signals:
         for lane in connector.lanes:
-            assert sig.stoppingPointOn(lane) is None
+            assert sig.stoppingPositionOn(lane) is None
 
 
 def test_carla_dummy_signal_reference_on_exit(tmp_path):
@@ -330,9 +467,9 @@ def test_carla_dummy_signal_reference_on_exit(tmp_path):
     clone = signal_on(east, 201)
     assert clone.validity == (0, 0)
     assert clone.orientation == "+"  # lamp facing; would wrongly pick the exit
-    _xy(clone.stoppingPointOn(lanes[1]), 32.0, 1.75)
-    assert clone.stoppingPointOn(lanes[-1]) is None
-    assert lanes[-1].haltPointAhead(Vector(33.0, -1.75)) is None
+    _st(clone.stoppingPositionOn(lanes[1]), 0.0, 1.75)
+    assert clone.stoppingPositionOn(lanes[-1]) is None
+    assert lanes[-1].haltPositionAhead(Vector(33.0, -1.75)) is None
 
 
 # --- CARLA / RoadRunner undefined (dummy 0–0, pole only) ---
@@ -353,25 +490,25 @@ def test_carla_twoway_arriving_side_halts_leaving_side_does_not(tmp_path):
     assert east_light.stoppingS == 0.0
 
     # West +s is arriving at the junction.
-    _xy(west_light.stoppingPointOn(west_lanes[-1]), 20.0, -1.75)
-    assert west_light.stoppingPointOn(west_lanes[1]) is None
+    _st(west_light.stoppingPositionOn(west_lanes[-1]), 20.0, -1.75)
+    assert west_light.stoppingPositionOn(west_lanes[1]) is None
 
     # East +s is the road you turn into; −s is the opposite approach.
-    assert east_light.stoppingPointOn(east_lanes[-1]) is None
-    _xy(east_light.stoppingPointOn(east_lanes[1]), 32.0, 1.75)
+    assert east_light.stoppingPositionOn(east_lanes[-1]) is None
+    _st(east_light.stoppingPositionOn(east_lanes[1]), 0.0, 1.75)
 
 
 def test_carla_green_light_then_no_stop_on_exit_lane(tmp_path):
-    """After the west stop, haltPointAhead on the east exit lane is empty."""
+    """After the west stop, haltPositionAhead on the east exit lane is empty."""
     network = load_network(tmp_path, MAP_CARLA_TWOWAY)
     west = road_by_id(network, 1)
     east = road_by_id(network, 2)
     west_fwd = lanes_by_id(west)[-1]
     east_fwd = lanes_by_id(east)[-1]
-    _xy(west_fwd.haltPointAhead(Vector(1.0, -1.75)), 20.0, -1.75)
-    assert east_fwd.haltPointAhead(Vector(33.0, -1.75)) is None
+    _st(west_fwd.haltPositionAhead(Vector(1.0, -1.75)), 20.0, -1.75)
+    assert east_fwd.haltPositionAhead(Vector(33.0, -1.75)) is None
     # Exactly at the east road start (s=0) must not count as a stop either.
-    assert east_fwd.haltPointAhead(Vector(32.0, -1.75)) is None
+    assert east_fwd.haltPositionAhead(Vector(32.0, -1.75)) is None
 
 
 def test_carla_connector_lights_do_not_invent_a_stop(tmp_path):
@@ -380,7 +517,7 @@ def test_carla_connector_lights_do_not_invent_a_stop(tmp_path):
         for sig in road.signals:
             assert sig.stoppingS is None
             for lane in road.lanes:
-                assert sig.stoppingPointOn(lane) is None
+                assert sig.stoppingPositionOn(lane) is None
 
 
 @pytest.mark.slow
@@ -406,7 +543,7 @@ def test_town01_exit_lane_does_not_halt_at_entry(getAssetPath):
         for sig in road1.signals
         if sig.stoppingS is not None and abs(sig.stoppingS) <= 1e-4
     )
-    assert entry_light.stoppingPointOn(arriving) is not None
-    assert entry_light.stoppingPointOn(leaving) is None
+    assert entry_light.stoppingPositionOn(arriving) is not None
+    assert entry_light.stoppingPositionOn(leaving) is None
     start = leaving.centerline.pointAlongBy(1.0)
-    assert leaving.haltPointAhead(start, lookahead=15.0) is None
+    assert leaving.haltPositionAhead(start, lookahead=15.0) is None

--- a/tests/formats/opendrive/test_signal_halt_encodings.py
+++ b/tests/formats/opendrive/test_signal_halt_encodings.py
@@ -2,8 +2,6 @@
 
 Junction-contact traffic lights must stop only the arriving direction. The lane
 you turn into at the far side of a green light must not inherit a halt at s=0.
-OpenDRIVE ``<validity>`` is ignored: CARLA's dummy 0–0 range is lamp facing,
-not a lane filter, so arrival at the halt station is used instead.
 """
 
 from pathlib import Path
@@ -233,6 +231,48 @@ MAP_CARLA_SIGNAL_REFERENCE = MAP_SIGNAL_REFERENCE.replace(
     '<signalReference s="1.5" t="4.0" id="201" orientation="+">\n'
     '        <validity fromLane="0" toLane="0"/>\n'
     "      </signalReference>",
+)
+
+MAP_CONNECTOR_HOSTED_LIGHT = (
+    MAP_CARLA_TWOWAY.replace(
+        """    <signals>
+      <signal s="18.5" t="-4.5" id="362" name="Signal_3Light_Post01" dynamic="yes"
+              orientation="-" zOffset="0" type="1000001" country="OpenDRIVE"
+              subtype="-1" value="-1">
+        <validity fromLane="0" toLane="0"/>
+      </signal>
+    </signals>
+""",
+        "",
+    )
+    .replace(
+        """    <signals>
+      <signal s="1.5" t="4.5" id="360" name="Signal_3Light_Post01" dynamic="yes"
+              orientation="+" zOffset="0" type="1000001" country="OpenDRIVE"
+              subtype="-1" value="-1">
+        <validity fromLane="0" toLane="0"/>
+      </signal>
+    </signals>
+""",
+        "",
+    )
+    .replace(
+        """      </laneSection>
+    </lanes>
+  </road>
+  <junction name="J" id="100">
+""",
+        """      </laneSection>
+    </lanes>
+    <signals>
+      <signal s="2.0" t="-4.0" id="500" name="connector_light" dynamic="yes"
+              orientation="+" zOffset="5" type="1000001" country="OpenDRIVE"
+              subtype="-1" value="-1"/>
+    </signals>
+  </road>
+  <junction name="J" id="100">
+""",
+    )
 )
 
 
@@ -523,10 +563,7 @@ def test_carla_green_light_then_no_stop_on_exit_lane(tmp_path):
 def test_carla_connector_lights_do_not_invent_a_stop(tmp_path):
     network = load_network(tmp_path, MAP_CARLA_TWOWAY)
     for road in network.connectingRoads:
-        for sig in road.signals:
-            assert sig.stoppingS is None
-            for lane in road.lanes:
-                assert sig.stoppingPositionOn(lane) is None
+        assert road.signals == ()
 
 
 def test_signal_parents_are_hosting_road_and_optional_intersection(tmp_path):
@@ -535,6 +572,8 @@ def test_signal_parents_are_hosting_road_and_optional_intersection(tmp_path):
     for sig in road.signals:
         assert sig.road is road
         assert sig.intersection is None
+        assert sig in network.signals
+    assert set(network.signals) == set(road.signals)
 
     network = load_network(tmp_path, MAP_CARLA_TWOWAY)
     west = road_by_id(network, 1)
@@ -547,11 +586,34 @@ def test_signal_parents_are_hosting_road_and_optional_intersection(tmp_path):
     assert west_light.intersection is not None
     assert west in west_light.intersection.roads
     assert east in east_light.intersection.roads
+    assert west_light in west_light.intersection.signals
+    assert east_light in east_light.intersection.signals
+    assert west_light in network.signals
+    assert east_light in network.signals
 
     for connector in network.connectingRoads:
-        for sig in connector.signals:
-            assert sig.road is connector
-            assert sig.intersection is west_light.intersection
+        assert connector.signals == ()
+
+    for sig in network.signals:
+        assert sig.road is not None
+        assert sig in sig.road.signals
+        assert sig.road not in network.connectingRoads
+
+
+def test_connector_signal_parents_incoming_road_and_intersection(tmp_path):
+    network = load_network(tmp_path, MAP_CONNECTOR_HOSTED_LIGHT)
+    west = road_by_id(network, 1)
+    light = signal_on(west, 500)
+    assert light is west.signals[-1]
+    assert light.road is west
+    assert light.intersection is not None
+    assert light in light.intersection.signals
+    assert light in network.signals
+    assert west in light.intersection.roads
+    assert light.stoppingS == pytest.approx(west.centerline.length)
+    for connector in network.connectingRoads:
+        assert connector.signals == ()
+        assert light not in connector.signals
 
 
 @pytest.mark.slow

--- a/tests/formats/opendrive/test_signal_halt_encodings.py
+++ b/tests/formats/opendrive/test_signal_halt_encodings.py
@@ -338,7 +338,6 @@ def test_deprecated_position_road_halts_at_logical_s_not_pole(tmp_path):
     road = road_by_id(network, 1)
     lanes = lanes_by_id(road)
     stop = signal_on(road, 10)
-    assert stop.sIsLogical
     assert stop.s == 12.0
     assert stop.stoppingS == 12.0
     assert stop.stoppingPositionOn(lanes[-1]) is None
@@ -350,7 +349,6 @@ def test_deprecated_position_inertial_halts_at_logical_s(tmp_path):
     road = road_by_id(network, 1)
     lanes = lanes_by_id(road)
     yield_sig = signal_on(road, 11)
-    assert yield_sig.sIsLogical
     assert yield_sig.stoppingS == 28.0
     _st(yield_sig.stoppingPositionOn(lanes[-1]), 28.0, -1.75)
     assert yield_sig.stoppingPositionOn(lanes[1]) is None
@@ -362,7 +360,6 @@ def test_deprecated_midroad_stopline_still_both_directions(tmp_path):
     road = road_by_id(network, 1)
     lanes = lanes_by_id(road)
     line = signal_on(road, 12)
-    assert not line.sIsLogical
     assert line.stoppingS == 20.0
     _st(line.stoppingPositionOn(lanes[-1]), 20.0, -1.75)
     _st(line.stoppingPositionOn(lanes[1]), 20.0, 1.75)
@@ -531,6 +528,31 @@ def test_carla_connector_lights_do_not_invent_a_stop(tmp_path):
             assert sig.stoppingS is None
             for lane in road.lanes:
                 assert sig.stoppingPositionOn(lane) is None
+
+
+def test_signal_parents_are_hosting_road_and_optional_intersection(tmp_path):
+    network = load_network(tmp_path, MAP_DEPRECATED_LOGICAL)
+    road = road_by_id(network, 1)
+    for sig in road.signals:
+        assert sig.road is road
+        assert sig.intersection is None
+
+    network = load_network(tmp_path, MAP_CARLA_TWOWAY)
+    west = road_by_id(network, 1)
+    east = road_by_id(network, 2)
+    west_light = signal_on(west, 362)
+    east_light = signal_on(east, 360)
+    assert west_light.road is west
+    assert east_light.road is east
+    assert west_light.intersection is east_light.intersection
+    assert west_light.intersection is not None
+    assert west in west_light.intersection.roads
+    assert east in east_light.intersection.roads
+
+    for connector in network.connectingRoads:
+        for sig in connector.signals:
+            assert sig.road is connector
+            assert sig.intersection is west_light.intersection
 
 
 @pytest.mark.slow

--- a/tests/formats/opendrive/test_signal_halt_encodings.py
+++ b/tests/formats/opendrive/test_signal_halt_encodings.py
@@ -1,7 +1,9 @@
-"""Halt-point encodings: deprecated logical-s, signalReference, and CARLA dummy validity.
+"""Halt-point encodings: deprecated logical-s, signalReference, and CARLA maps.
 
 Junction-contact traffic lights must stop only the arriving direction. The lane
 you turn into at the far side of a green light must not inherit a halt at s=0.
+OpenDRIVE ``<validity>`` is ignored: CARLA's dummy 0–0 range is lamp facing,
+not a lane filter, so arrival at the halt station is used instead.
 """
 
 from pathlib import Path
@@ -475,7 +477,6 @@ def test_carla_dummy_signal_reference_on_exit(tmp_path):
     east = road_by_id(network, 2)
     lanes = lanes_by_id(east)
     clone = signal_on(east, 201)
-    assert clone.validity == (0, 0)
     assert clone.orientation == "+"  # lamp facing; would wrongly pick the exit
     _st(clone.stoppingPositionOn(lanes[1]), 0.0, 1.75)
     assert clone.stoppingPositionOn(lanes[-1]) is None
@@ -494,8 +495,6 @@ def test_carla_twoway_arriving_side_halts_leaving_side_does_not(tmp_path):
     west_light = signal_on(west, 362)
     east_light = signal_on(east, 360)
 
-    assert west_light.validity == (0, 0)
-    assert east_light.validity == (0, 0)
     assert west_light.stoppingS == 20.0
     assert east_light.stoppingS == 0.0
 


### PR DESCRIPTION
## Summary
- preserve OpenDRIVE signal placement, validity, semantics, and element references
- derive a longitudinal stopping station separately from the physical signal position
- expose lane-specific and next-ahead halt points while excluding outgoing junction lanes

## Test plan
- [x] `pytest -q tests/formats/opendrive/test_signal_halt_encodings.py`
- [x] `pytest -q tests/formats/opendrive/test_opendrive.py`
- [x] Black formatting check for changed files