### PR TITLE
Fix f-string conversion specifiers on Python 3.12+

### DIFF
--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -235,8 +235,8 @@ class Parser(Parser):
             self.raise_syntax_error_known_location("imaginary number required in complex literal", number)
         return value
 
-    def check_fstring_conversion(self, mark: tokenize.TokenInfo, name: tokenize.TokenInfo) -> tokenize.TokenInfo:
-        if mark.lineno != name.lineno or mark.col_offset != name.col_offset:
+    def check_fstring_conversion(self, mark: tokenize.TokenInfo, name: tokenize.TokenInfo) -> int:
+        if mark.end != name.start:
             self.raise_syntax_error_known_range(
                 "f-string: conversion type must come right after the exclamanation mark",
                 mark,
@@ -250,7 +250,7 @@ class Parser(Parser):
                 name,
             )
 
-        return name
+        return ord(s)
 
     def _concat_strings_in_constant(self, parts) -> Union[str, bytes]:
         s = ast.literal_eval(parts[0].string)
@@ -2204,9 +2204,9 @@ fstring_replacement_field:
         ast.FormattedValue(
             value=a,
             conversion=(
-                conversion.decode()[0]
-                if conversion else
-                (b'r'[0] if debug_expr else -1)
+                conversion
+                if conversion is not None else
+                (ord('r') if debug_expr else -1)
             ),
             format_spec=format,
             LOCATIONS

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from scenic.core.errors import ScenicSyntaxError
+from scenic.core.errors import ScenicParseError, ScenicSyntaxError
 from scenic.syntax.ast import *
 from scenic.syntax.parser import parse_string
 
@@ -3040,3 +3040,20 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+
+def test_fstring_conversion_specifiers():
+    for conv_char, expected in [("r", ord("r")), ("s", ord("s")), ("a", ord("a"))]:
+        mod = parse_string_helper(
+            f"""
+            x = 3
+            param y = f"{{x!{conv_char}}}"
+            """
+        )
+        joined = mod.body[1].elts[0].value
+        assert joined.values[0].conversion == expected
+
+
+def test_fstring_invalid_conversion_specifier():
+    with pytest.raises(ScenicParseError, match="invalid conversion character"):
+        parse_string_helper('y = f"{x!z}"')


### PR DESCRIPTION
### Description
Fix parser crash on f-string conversion specifiers (`!r`, `!s`, `!a`) under Python 3.12+.

### Issue Link
Fixes #464

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
N/A