### PR TITLE
Fix OpenScenarioXML Tests

### DIFF
--- a/tests/domains/driving/test_driving.py
+++ b/tests/domains/driving/test_driving.py
@@ -7,9 +7,7 @@ import pytest
 from scenic.core.distributions import RejectionException
 from scenic.core.errors import InvalidScenarioError
 from scenic.core.geometry import TriangulationError
-from scenic.domains.driving.openscenario import toOpenScenario
 from scenic.domains.driving.roads import Network
-from scenic.simulators.newtonian import NewtonianSimulator
 from tests.utils import compileScenic, pickle_test, sampleEgo, sampleScene, tryPickling
 
 # Suppress all warnings from OpenDRIVE parser
@@ -231,56 +229,3 @@ def test_invalid_road_scenario(cached_maps):
             param foo = ego.lane
             """,
         )
-
-
-def test_xosc_export(getAssetPath):
-    simulator = NewtonianSimulator("Town01")
-    code = """
-        param render = False
-        model scenic.simulators.newtonian.driving_model
-
-        ego = new Car with behavior FollowLaneBehavior()
-
-        immobileCar = new Car visible
-
-        behavior Walk():
-            take SetWalkingSpeedAction(1)
-        
-        new Pedestrian behind ego by 5,
-            with regionContainedIn None,
-            with behavior Walk()
-    """
-
-    scenario = compileScenic(
-        code, mode2D=True, params={"map": getAssetPath("maps/CARLA/Town01.xodr")}
-    )
-    scene, _ = scenario.generate()
-    simulation = simulator.simulate(scene, maxSteps=50)
-    toOpenScenario(simulation, scenario, scene)
-
-
-def test_xosc_export_dynamic_objects(getAssetPath):
-    simulator = NewtonianSimulator("Town01")
-    code = """
-        param render = False
-        model scenic.simulators.newtonian.driving_model
-
-        scenario SpawnCar():
-            setup:
-                new Car at 0@0
-
-        scenario Main():
-            setup:
-                ego = new Car
-
-            compose:
-                wait for 1 seconds
-                do SpawnCar()
-    """
-    scenario = compileScenic(
-        code, mode2D=True, params={"map": getAssetPath("maps/CARLA/Town01.xodr")}
-    )
-    scene, _ = scenario.generate()
-    simulation = simulator.simulate(scene, maxSteps=50)
-    with pytest.raises(RuntimeError, match="(.*)dynamically created objects(.*)"):
-        toOpenScenario(simulation, scenario, scene)

--- a/tests/domains/driving/test_xosc.py
+++ b/tests/domains/driving/test_xosc.py
@@ -1,0 +1,63 @@
+import pytest
+
+from scenic.domains.driving.openscenario import toOpenScenario
+from scenic.simulators.newtonian import NewtonianSimulator
+from tests.utils import compileScenic
+
+try:
+    import scenariogeneration
+except ModuleNotFoundError:
+    pytest.skip("scenariogeneration package not installed", allow_module_level=True)
+
+
+def test_xosc_export(getAssetPath):
+    simulator = NewtonianSimulator("Town01")
+    code = """
+        param render = False
+        model scenic.simulators.newtonian.driving_model
+
+        ego = new Car with behavior FollowLaneBehavior()
+
+        immobileCar = new Car visible
+
+        behavior Walk():
+            take SetWalkingSpeedAction(1)
+        
+        new Pedestrian behind ego by 5,
+            with regionContainedIn None,
+            with behavior Walk()
+    """
+
+    scenario = compileScenic(
+        code, mode2D=True, params={"map": getAssetPath("maps/CARLA/Town01.xodr")}
+    )
+    scene, _ = scenario.generate()
+    simulation = simulator.simulate(scene, maxSteps=50)
+    toOpenScenario(simulation, scenario, scene)
+
+
+def test_xosc_export_dynamic_objects(getAssetPath):
+    simulator = NewtonianSimulator("Town01")
+    code = """
+        param render = False
+        model scenic.simulators.newtonian.driving_model
+
+        scenario SpawnCar():
+            setup:
+                new Car at 0@0
+
+        scenario Main():
+            setup:
+                ego = new Car
+
+            compose:
+                wait for 1 seconds
+                do SpawnCar()
+    """
+    scenario = compileScenic(
+        code, mode2D=True, params={"map": getAssetPath("maps/CARLA/Town01.xodr")}
+    )
+    scene, _ = scenario.generate()
+    simulation = simulator.simulate(scene, maxSteps=50)
+    with pytest.raises(RuntimeError, match="(.*)dynamically created objects(.*)"):
+        toOpenScenario(simulation, scenario, scene)


### PR DESCRIPTION
### Description
Fixes a test failure that occurs when the test suite is run without the optional `scenariogeneration` package.

### Issue Link
N/A

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A